### PR TITLE
Rename SocialNetwork component for clarity

### DIFF
--- a/src/components/contact/SocialNetwork.astro
+++ b/src/components/contact/SocialNetwork.astro
@@ -2,7 +2,7 @@
 import TikTokIcon from '../icons/TikTok.astro';
 import InstagramIcon from '../icons/Instagram.astro';
 import FacebookIcon from '../icons/Facebook.astro';
-import SocialNetwork from '../icons/SocialNetwork.astro';
+import SocialNetworkIcon from '../icons/SocialNetwork.astro';
 
 interface Props {
 	title?: string;
@@ -30,7 +30,7 @@ const {
 			<div class='flex-1 flex flex-col space-y-3'>
 				<div class='flex items-center mb-4'>
 					<span class='bg-primary text-white p-2 rounded-full mr-3'>
-						<SocialNetwork class='w-5 h-5' />
+						<SocialNetworkIcon class='w-5 h-5' />
 					</span>
 					<h3
 						class='font-bold text-lg md:text-xl lg:text-2xl text-primary-dark'>


### PR DESCRIPTION
Rename the SocialNetwork component to SocialNetworkIcon to enhance clarity in the codebase.