### PR TITLE
fix(ci): add CHANGELOG.md to prettierignore to prevent CI format check errors

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -7,3 +7,5 @@ public/images/
 public/icons/
 *.min.js
 *.min.css
+CHANGELOG.md
+


### PR DESCRIPTION
Adds CHANGELOG.md to `.prettierignore` to prevent CI validation failures. Since release-please generates the changelog using its own format settings, Prettier's validation would otherwise flag spacing/style discrepancies and fail the build check.