### PR TITLE
ci(vercel): disable Vercel auto-deploy for main and develop

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,11 @@
 {
   "framework": "astro",
   "buildCommand": "bun run build",
-  "outputDirectory": "dist"
+  "outputDirectory": "dist",
+  "git": {
+    "deploymentEnabled": {
+      "main": false,
+      "develop": false
+    }
+  }
 }


### PR DESCRIPTION
This PR configures Vercel to skip building on `main` and `develop` branches natively by adding an `ignoreCommand` to `vercel.json`. This ensures that Vercel auto-deployments don't conflict with GitHub Actions deployments for these branches.