### PR TITLE
chore(ci): ignore entire .astro directory in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
 # build output
 dist/
 
-# generated types (keep types.d.ts for CI, ignore cache)
-.astro/cache/
+# generated types and internal Astro data
+.astro/
 
 # dependencies
 node_modules/


### PR DESCRIPTION
Astro 4+ generates internal content collection types and caches within the `.astro` directory during `bun run check` and `bun run dev`. 
Previously, the `.gitignore` only ignored `.astro/cache/`, leading to untracked local changes for `.astro/collections/` and other generated artifacts.

This PR updates `.gitignore` to safely ignore the entire `.astro/` directory to prevent workspace pollution.