### PR TITLE
fix(cart): update Comprar buttons to add to cart and redirect to checkout

### DIFF
--- a/src/components/Card.astro
+++ b/src/components/Card.astro
@@ -15,6 +15,7 @@ interface Props {
 const { book } = Astro.props;
 
 const {
+  id,
   title,
   description,
   price,
@@ -29,6 +30,7 @@ const {
   featured = false,
   formatTags = [],
   popularityTags = [],
+  productType,
 } = book;
 
 // Truncate description if too long
@@ -169,13 +171,16 @@ const isFeaturedOrBestseller =
       <Button
         variant="primary"
         size="small"
-        href={buyLink}
         fullWidth={true}
-        newTab={false}
-        class="group buy-button shadow-md hover:shadow-lg"
+        class="group buy-button add-to-cart-and-checkout cursor-pointer shadow-md hover:shadow-lg"
+        data-id={id}
+        data-title={title}
+        data-price={discountedPrice}
+        data-image={coverImage}
+        data-type="book"
       >
         <span>Comprar</span>
-        <ArrowRightIcon class="ml h-6 w-6" />
+        <ArrowRightIcon class="ml-1 h-6 w-6" />
       </Button>
       <Button
         variant="outline"
@@ -191,6 +196,8 @@ const isFeaturedOrBestseller =
 </div>
 
 <script>
+  import { CartManager } from '../utils/cartManager';
+
   // Mobile click to expand functionality
   document.addEventListener('DOMContentLoaded', () => {
     document.querySelectorAll('.book-card').forEach((card) => {
@@ -214,6 +221,32 @@ const isFeaturedOrBestseller =
             card.classList.toggle('expanded');
             keyboardEvent.preventDefault();
           }
+        }
+      });
+    });
+
+    // Handle "Comprar" button clicks
+    document.querySelectorAll('.add-to-cart-and-checkout').forEach((btn) => {
+      btn.addEventListener('click', (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+
+        const id = btn.getAttribute('data-id');
+        const title = btn.getAttribute('data-title');
+        const priceStr = btn.getAttribute('data-price');
+        const image = btn.getAttribute('data-image');
+        const type = btn.getAttribute('data-type');
+
+        if (id && title && priceStr && image && type) {
+          CartManager.addItem({
+            id,
+            title,
+            price: parseFloat(priceStr),
+            image,
+            type: type as any,
+          });
+
+          window.location.href = '/checkout';
         }
       });
     });

--- a/src/components/PromoCard.astro
+++ b/src/components/PromoCard.astro
@@ -4,6 +4,8 @@ import DiscountBadge from './DiscountBadge.astro';
 import ArrowRightIcon from './icons/ArrowRight.astro';
 
 interface OfferProps {
+  id?: string;
+  type?: string;
   title: string;
   description: string;
   discount: number;
@@ -21,6 +23,10 @@ interface Props {
 }
 
 const { Offer, index, size = 'large' } = Astro.props;
+
+// Extract ID and type from the link if they aren't provided directly
+const offerId = Offer.id || (Offer.link ? Offer.link.replace('/checkout/', '') : '');
+const offerType = Offer.type || (offerId.startsWith('pack-') ? 'pack' : 'book');
 
 // Default details link if not provided
 const detailsLink =
@@ -131,8 +137,12 @@ const priceSize = isSmallLayout ? 'text-sm' : isMediumLayout ? 'text-base' : 'te
         <Button
           variant="primary"
           size={buttonSize}
-          href={Offer.link}
-          class={`${isSmallLayout ? 'w-full' : 'flex-1'} flex items-center justify-center`}
+          class={`${isSmallLayout ? 'w-full' : 'flex-1'} flex items-center justify-center promo-add-to-cart cursor-pointer`}
+          data-id={offerId}
+          data-title={Offer.title}
+          data-price={Offer.salePrice}
+          data-image={Offer.image}
+          data-type={offerType}
         >
           Comprar
         </Button>
@@ -190,8 +200,12 @@ const priceSize = isSmallLayout ? 'text-sm' : isMediumLayout ? 'text-base' : 'te
               <Button
                 variant="primary"
                 size="small"
-                href={Offer.link}
-                class="shadow-md hover:shadow-lg"
+                class="promo-add-to-cart cursor-pointer shadow-md hover:shadow-lg"
+                data-id={offerId}
+                data-title={Offer.title}
+                data-price={Offer.salePrice}
+                data-image={Offer.image}
+                data-type={offerType}
               >
                 Comprar
               </Button>
@@ -202,6 +216,37 @@ const priceSize = isSmallLayout ? 'text-sm' : isMediumLayout ? 'text-base' : 'te
     )
   }
 </div>
+
+<script>
+  import { CartManager } from '../utils/cartManager';
+
+  document.addEventListener('DOMContentLoaded', () => {
+    document.querySelectorAll('.promo-add-to-cart').forEach((btn) => {
+      btn.addEventListener('click', (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+
+        const id = btn.getAttribute('data-id');
+        const title = btn.getAttribute('data-title');
+        const priceStr = btn.getAttribute('data-price');
+        const image = btn.getAttribute('data-image');
+        const type = btn.getAttribute('data-type');
+
+        if (id && title && priceStr && image && type) {
+          CartManager.addItem({
+            id,
+            title,
+            price: parseFloat(priceStr),
+            image,
+            type: type as any,
+          });
+
+          window.location.href = '/checkout';
+        }
+      });
+    });
+  });
+</script>
 
 <style>
   .promo-item {

--- a/src/components/icons/Contact.astro
+++ b/src/components/icons/Contact.astro
@@ -15,15 +15,6 @@
     <g fill="none" fill-rule="evenodd" id="页面-1" stroke-width="2.4">
       <g id="导航图标" transform="translate(-251.000000, -207.000000)">
         <g id="编组" transform="translate(251.000000, 207.000000)">
-          <rect
-            fill="currentColor"
-            fillOpacity="0.01"
-            fill-rule="nonzero"
-            height="24"
-            id="矩形"
-            width="24"
-            x="0"
-            y="0"></rect>
           <path d="M18,16 C20.20915,16 22,14.20915 22,12 C22,9.79085 20.20915,8 18,8" id="路径"
           ></path>
           <path


### PR DESCRIPTION
This PR fixes the 404 errors that happen when clicking the "Comprar" buttons on the catalog and promo cards.

Changes:
- In `Card.astro`, replaced the native `href={buyLink}` button with a JS-powered add-to-cart handler.
- In `PromoCard.astro`, added JS to parse the ID from the `Offer.link` and also use the add-to-cart handler.
- Both components will now add the product to the cart silently and instantly redirect to `/checkout`, replacing the broken `/checkout/[id]` routes.