### PR TITLE
test(ci): add unit and e2e coverage for catalog, cart and checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,3 +74,50 @@ jobs:
           name: dist
           path: dist/
           retention-days: 7
+
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run unit tests
+        run: bun run test:unit
+
+  test-e2e:
+    name: test-e2e
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Install Playwright browsers
+        run: bunx playwright install --with-deps chromium
+
+      - name: Run E2E smoke tests
+        run: bun run test:e2e
+
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,12 @@ pnpm-debug.log*
 # test coverage
 coverage/
 
+# Playwright E2E output
+test-results/
+playwright-report/
+blob-report/
+playwright/.cache/
+
 # personal AI/MCP configs (do not commit)
 .mcp.json
 .claude/settings.local.json

--- a/bun.lock
+++ b/bun.lock
@@ -19,12 +19,15 @@
       },
       "devDependencies": {
         "@astrojs/check": "^0.9.9",
-        "@commitlint/cli": "^21.2.0",
+        "@axe-core/playwright": "^4.12.1",
+        "@commitlint/cli": "^21.2.1",
         "@commitlint/config-conventional": "^21.2.0",
         "@eslint/js": "^10.0.1",
-        "@typescript-eslint/eslint-plugin": "^8.62.1",
-        "@typescript-eslint/parser": "^8.62.1",
-        "eslint": "^10.6.0",
+        "@playwright/test": "^1.60.0",
+        "@types/bun": "^1.3.14",
+        "@typescript-eslint/eslint-plugin": "^8.64.0",
+        "@typescript-eslint/parser": "^8.64.0",
+        "eslint": "^10.7.0",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-astro": "^2.1.1",
         "eslint-plugin-jsx-a11y": "^6.10.2",
@@ -32,9 +35,9 @@
         "eslint-plugin-react-hooks": "^7.1.1",
         "husky": "^9.1.7",
         "lint-staged": "^17.0.8",
-        "prettier": "^3.9.4",
+        "prettier": "^3.9.5",
         "prettier-plugin-astro": "^0.14.1",
-        "prettier-plugin-tailwindcss": "^0.8.0",
+        "prettier-plugin-tailwindcss": "^0.8.1",
         "typescript": "^6.0.3",
       },
     },
@@ -81,6 +84,8 @@
     "@astrojs/telemetry": ["@astrojs/telemetry@3.3.2", "", { "dependencies": { "ci-info": "^4.4.0", "dset": "^3.1.4", "is-docker": "^4.0.0", "is-wsl": "^3.1.1", "which-pm-runs": "^1.1.0" } }, "sha512-j8DNruA8ors99Al39RYZPJK4DC1bKkoNm93mAMuBhY9TCNC4R8n1q7ovFnJ5qhGh5Lsh7pa1gpQVpYpsJPeTHQ=="],
 
     "@astrojs/yaml2ts": ["@astrojs/yaml2ts@0.2.4", "", { "dependencies": { "yaml": "^2.8.3" } }, "sha512-8oddpOae35pJsXPQXhTkM0ypfKPskVsh2bCxRtbf7e+/Epw2nReakFYpLKjZMEr75CsoF203PMnCocpfz0s69A=="],
+
+    "@axe-core/playwright": ["@axe-core/playwright@4.12.1", "", { "dependencies": { "axe-core": "~4.12.1" }, "peerDependencies": { "playwright-core": ">= 1.0.0" } }, "sha512-rMd7xriptqKpP+w5265i4Hdkv2X5kbu6uiBi/B2I7uf3hieRBM3qDCfaKPtxfiYb2mKXfF+yLODJwIx+Jv1GDw=="],
 
     "@babel/code-frame": ["@babel/code-frame@7.29.7", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw=="],
 
@@ -356,6 +361,8 @@
 
     "@pkgr/core": ["@pkgr/core@0.3.6", "", {}, "sha512-SEeaJLb3qBNF/OaXnaR1NmmBbFYk1zC0ZH/52fATcRPLFg/p791YrcyFFy44Bo9sLaGuSuLp5Q6axbb/O+v/RA=="],
 
+    "@playwright/test": ["@playwright/test@1.62.1", "", { "dependencies": { "playwright": "1.62.1" }, "bin": { "playwright": "cli.js" } }, "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ=="],
+
     "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.1.4", "", { "os": "android", "cpu": "arm64" }, "sha512-EZLpf/8y7GXkkra90ML47kzik/GMP3EMcE9bPyHmRfxLC6z9+aW5A8poCsoxjrT5GfEcNAAvWwUHjvP1pUQkfw=="],
 
     "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.1.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-aUi+HBvmYb7j8krl1+qJgkG8C17fO79gk3c+jPw4S8glRFc1DTija9S3EyaTSQUm5GJXYKDAsugBEhFHH2vYiQ=="],
@@ -488,6 +495,8 @@
 
     "@types/babel__traverse": ["@types/babel__traverse@7.20.6", "", { "dependencies": { "@babel/types": "^7.20.7" } }, "sha512-r1bzfrm0tomOI8g1SzvCaQHo6Lcv6zu0EA+W2kHrt8dyrHQxGzBBL4kdkzIS+jBMV+EYcMAEAqXqYaLJq5rOZg=="],
 
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
     "@types/esrecurse": ["@types/esrecurse@4.3.1", "", {}, "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw=="],
 
     "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
@@ -617,6 +626,8 @@
     "brace-expansion": ["brace-expansion@5.0.7", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA=="],
 
     "browserslist": ["browserslist@4.24.4", "", { "dependencies": { "caniuse-lite": "^1.0.30001688", "electron-to-chromium": "^1.5.73", "node-releases": "^2.0.19", "update-browserslist-db": "^1.1.1" }, "bin": { "browserslist": "cli.js" } }, "sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "call-bind": ["call-bind@1.0.9", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "get-intrinsic": "^1.3.0", "set-function-length": "^1.2.2" } }, "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ=="],
 
@@ -842,7 +853,7 @@
 
     "for-each": ["for-each@0.3.5", "", { "dependencies": { "is-callable": "^1.2.7" } }, "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg=="],
 
-    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+    "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
@@ -1171,6 +1182,10 @@
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "picomatch": ["picomatch@4.0.5", "", {}, "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="],
+
+    "playwright": ["playwright@1.62.1", "", { "dependencies": { "playwright-core": "1.62.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg=="],
+
+    "playwright-core": ["playwright-core@1.62.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw=="],
 
     "possible-typed-array-names": ["possible-typed-array-names@1.1.0", "", {}, "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="],
 
@@ -1580,6 +1595,8 @@
 
     "rollup/@types/estree": ["@types/estree@1.0.6", "", {}, "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw=="],
 
+    "rollup/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
     "sharp/semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
 
     "sitemap/@types/node": ["@types/node@24.13.2", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA=="],
@@ -1591,6 +1608,8 @@
     "typescript-auto-import-cache/semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
 
     "unstorage/chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
+
+    "vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "volar-service-typescript/semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -9,7 +9,15 @@ import prettier from 'eslint-config-prettier';
 
 export default [
   {
-    ignores: ['dist/', '.astro/', 'node_modules/', 'public/', '*.config.mjs', '*.config.cjs'],
+    ignores: [
+      'dist/',
+      '.astro/',
+      'node_modules/',
+      'public/',
+      '*.config.mjs',
+      '*.config.cjs',
+      'playwright.config.ts',
+    ],
   },
   {
     ...js.configs.recommended,
@@ -98,6 +106,7 @@ export default [
         // DOM types
         Image: 'readonly',
         NodeListOf: 'readonly',
+        Storage: 'readonly',
       },
     },
     plugins: {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
+    "test:unit": "bun test tests/unit",
+    "test:e2e": "playwright test",
+    "test": "bun run test:unit",
     "prepare": "husky"
   },
   "dependencies": {
@@ -36,9 +39,12 @@
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.9",
+    "@axe-core/playwright": "^4.12.1",
     "@commitlint/cli": "^21.2.1",
     "@commitlint/config-conventional": "^21.2.0",
     "@eslint/js": "^10.0.1",
+    "@playwright/test": "^1.60.0",
+    "@types/bun": "^1.3.14",
     "@typescript-eslint/eslint-plugin": "^8.64.0",
     "@typescript-eslint/parser": "^8.64.0",
     "eslint": "^10.7.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,37 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * E2E smoke coverage for the core conversion path (catalog -> detail ->
+ * cart -> WhatsApp checkout). Runs against the Astro dev server, which
+ * serves the same routes/content as the static build without requiring a
+ * prior `astro build`.
+ */
+export default defineConfig({
+  testDir: './tests/e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? [['list'], ['html', { open: 'never' }]] : 'list',
+  use: {
+    baseURL: 'http://localhost:4321',
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: 'bun run dev',
+    url: 'http://localhost:4321',
+    reuseExistingServer: !process.env.CI,
+    timeout: 60_000,
+    // `astro dev` auto-detects AI coding agents and backgrounds itself
+    // (see https://docs.astro.build/en/guides/build-with-ai/#background-mode),
+    // which orphans the process Playwright is trying to manage. Force it to
+    // stay attached so Playwright can track readiness and shut it down.
+    env: { ASTRO_DEV_BACKGROUND: '0' },
+  },
+});

--- a/src/components/Card.astro
+++ b/src/components/Card.astro
@@ -3,6 +3,7 @@ import Button from './Button.astro';
 import { PopularityTag } from '../types/book';
 import type { Book } from '../types/book';
 import { levelConfig, popularityConfig, formatConfig } from '../utils/bookTags';
+import { calculateDiscountedPrice } from '../utils/pricing';
 import ArrowRightIcon from './icons/ArrowRight.astro';
 import '../styles/Card.css';
 import BookTags from './BookTags.astro';
@@ -37,7 +38,7 @@ const truncatedDescription =
 
 // Price calculations
 const hasDiscount = discount > 0;
-const discountedPrice = hasDiscount ? price * (1 - discount / 100) : price;
+const discountedPrice = calculateDiscountedPrice(price, discount);
 const formattedPrice = `S/${price.toFixed(2)}`;
 const formattedDiscountedPrice = `S/${discountedPrice.toFixed(2)}`;
 
@@ -53,15 +54,12 @@ const isFeaturedOrBestseller =
 
 <div
   class:list={[
-    'book-card book-card-tilt focus-visible:ring-primary flex h-full w-full max-w-sm transform flex-col overflow-hidden rounded-xl bg-white transition-all duration-500 focus:outline-none focus-visible:ring-2',
+    'book-card book-card-tilt flex h-full w-full max-w-sm transform flex-col overflow-hidden rounded-xl bg-white transition-all duration-500',
     isFeaturedOrBestseller
       ? 'card-highlighted shadow-xl hover:-translate-y-2 hover:shadow-2xl'
       : 'shadow-md hover:-translate-y-1 hover:shadow-xl',
     isSpecialOffer && 'special-offer-card',
   ]}
-  tabindex="0"
-  role="button"
-  aria-label={`Detalles de libro: ${title}. Presiona para expandir en dispositivos móviles.`}
 >
   <!-- Book Cover Image with Badge -->
   <div class="book-cover-container relative h-52 overflow-hidden">
@@ -196,7 +194,9 @@ const isFeaturedOrBestseller =
 <script>
   import { CartManager } from '../utils/cartManager';
 
-  // Mobile click to expand functionality
+  // Mobile click to expand functionality. The card itself is not a focusable
+  // control (the real "Ver Detalles" link and "Comprar" button already cover
+  // keyboard/screen-reader interaction), so this is mouse/touch-only.
   document.addEventListener('DOMContentLoaded', () => {
     document.querySelectorAll('.book-card').forEach((card) => {
       card.addEventListener('click', (e) => {
@@ -204,20 +204,6 @@ const isFeaturedOrBestseller =
           const target = e.target as Element;
           if (target && !target.closest('a') && !target.closest('button')) {
             card.classList.toggle('expanded');
-          }
-        }
-      });
-
-      card.addEventListener('keydown', (e) => {
-        const keyboardEvent = e as KeyboardEvent;
-        if (
-          window.innerWidth <= 768 &&
-          (keyboardEvent.key === 'Enter' || keyboardEvent.key === ' ')
-        ) {
-          const target = keyboardEvent.target as Element;
-          if (target && !target.closest('a') && !target.closest('button')) {
-            card.classList.toggle('expanded');
-            keyboardEvent.preventDefault();
           }
         }
       });

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -88,7 +88,7 @@ const footerLinks = [
               type="email"
               name="email"
               placeholder="Tu correo electrónico"
-              class="focus:ring-secondary bg-primary-light min-h-11 min-w-0 flex-grow rounded-full px-4 py-2 text-sm text-white focus:ring-2 focus:outline-none md:py-3 md:text-base"
+              class="focus:ring-secondary bg-primary-dark min-h-11 min-w-0 flex-grow rounded-full px-4 py-2 text-sm text-white focus:ring-2 focus:outline-none md:py-3 md:text-base"
               aria-label="Correo electrónico para boletín informativo"
               required
             />

--- a/src/components/ProductCard.astro
+++ b/src/components/ProductCard.astro
@@ -4,6 +4,7 @@ import BookTags from './BookTags.astro';
 import Button from './Button.astro';
 import { levelConfig, formatConfig, popularityConfig } from '../utils/bookTags';
 import { difficultyConfig } from '../utils/examTags';
+import { calculateDiscountedPrice } from '../utils/pricing';
 import type { Product } from '../types/product';
 import type { FormatTag, PopularityTag } from '../types/book';
 import '../styles/Card.css';
@@ -38,7 +39,7 @@ const {
 
 // Calculate discount if provided
 const hasDiscount = discount > 0;
-const discountedPrice = hasDiscount ? price * (1 - discount / 100) : price;
+const discountedPrice = calculateDiscountedPrice(price, discount);
 const finalPrice = discountedPrice;
 
 // Format prices

--- a/src/components/catalog/CategoryCards.astro
+++ b/src/components/catalog/CategoryCards.astro
@@ -43,7 +43,7 @@ const iconMap: Record<string, (_props: Record<string, unknown>) => unknown> = {
               </h3>
               <p class="text-primary mb-4 text-sm">{category.description}</p>
 
-              <div class="text-secondary-dark inline-flex items-center text-sm font-medium transition-transform duration-300 group-hover:translate-x-2">
+              <div class="text-primary-dark inline-flex items-center text-sm font-medium transition-transform duration-300 group-hover:translate-x-2">
                 <span>Explorar</span>
                 <ArrowRightIcon class="ml-1 h-4 w-4" />
               </div>

--- a/src/pages/checkout.astro
+++ b/src/pages/checkout.astro
@@ -70,6 +70,7 @@ const whatsappNumber = siteConfig.whatsapp;
 
 <script>
   import { CartManager, type CartItem } from '@utils/cartManager';
+  import { buildWhatsAppMessage, buildWhatsAppUrl } from '@utils/checkoutMessage';
 
   document.addEventListener('DOMContentLoaded', () => {
     const checkoutDataEl = document.getElementById('checkout-data');
@@ -291,16 +292,10 @@ const whatsappNumber = siteConfig.whatsapp;
       const total = CartManager.getCartTotal();
 
       // Prepare WhatsApp message
-      let message = `*Nuevo pedido desde FluentReads*\n\n*Productos:*\n`;
-
-      cart.forEach((item: CartItem, index: number) => {
-        message += `${index + 1}. ${item.title} (${item.quantity}x) - S/${(item.price * item.quantity).toFixed(2)}\n`;
-      });
-
-      message += `\n*Total: S/${total.toFixed(2)}*\n\nPor favor, confirmame este pedido para enviarte los datos de pago. ¡Gracias!`;
+      const message = buildWhatsAppMessage(cart, total);
 
       // Open WhatsApp with the message
-      window.open(`https://wa.me/${whatsappNumber}?text=${encodeURIComponent(message)}`, '_blank');
+      window.open(buildWhatsAppUrl(whatsappNumber, message), '_blank');
     });
 
     // Listen for cart update events

--- a/src/utils/checkoutMessage.ts
+++ b/src/utils/checkoutMessage.ts
@@ -1,0 +1,25 @@
+import type { CartItem } from './cartManager';
+import { formatPEN } from './pricing';
+
+/**
+ * Build the WhatsApp order message from the current cart contents.
+ * Extracted from checkout.astro so the exact wording/format is unit-testable.
+ */
+export function buildWhatsAppMessage(cart: CartItem[], total: number): string {
+  let message = `*Nuevo pedido desde FluentReads*\n\n*Productos:*\n`;
+
+  cart.forEach((item, index) => {
+    message += `${index + 1}. ${item.title} (${item.quantity}x) - ${formatPEN(item.price * item.quantity)}\n`;
+  });
+
+  message += `\n*Total: ${formatPEN(total)}*\n\nPor favor, confirmame este pedido para enviarte los datos de pago. ¡Gracias!`;
+
+  return message;
+}
+
+/**
+ * Build the wa.me deep link that opens WhatsApp with the order message prefilled.
+ */
+export function buildWhatsAppUrl(phoneNumber: string, message: string): string {
+  return `https://wa.me/${phoneNumber}?text=${encodeURIComponent(message)}`;
+}

--- a/src/utils/pricing.ts
+++ b/src/utils/pricing.ts
@@ -1,0 +1,22 @@
+/**
+ * Pricing helpers shared by product cards and checkout.
+ * Keeping discount math and currency formatting in one place avoids
+ * duplicated `price * (1 - discount / 100)` formulas drifting apart.
+ */
+
+/**
+ * Apply a percentage discount to a price.
+ * @param price Base price (PEN)
+ * @param discountPercent Discount percentage in the 0-100 range
+ */
+export function calculateDiscountedPrice(price: number, discountPercent: number = 0): number {
+  if (!discountPercent || discountPercent <= 0) return price;
+  return price * (1 - discountPercent / 100);
+}
+
+/**
+ * Format an amount as Peruvian Sol currency (S/1234.50).
+ */
+export function formatPEN(amount: number): string {
+  return `S/${amount.toFixed(2)}`;
+}

--- a/tests/e2e/accessibility.spec.ts
+++ b/tests/e2e/accessibility.spec.ts
@@ -1,0 +1,23 @@
+import { test, expect } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
+
+/**
+ * Locks in the current accessibility baseline for the two highest-traffic
+ * pages. Only fails on "serious"/"critical" violations so unrelated
+ * moderate/minor findings (tracked separately) don't block this suite.
+ */
+test.describe('Accessibility baseline', () => {
+  for (const path of ['/', '/catalogo']) {
+    test(`${path} has no serious or critical axe violations`, async ({ page }) => {
+      await page.goto(path, { waitUntil: 'networkidle' });
+
+      const results = await new AxeBuilder({ page }).withTags(['wcag2a', 'wcag2aa']).analyze();
+
+      const seriousOrCritical = results.violations.filter((v) =>
+        ['serious', 'critical'].includes(v.impact ?? '')
+      );
+
+      expect(seriousOrCritical, JSON.stringify(seriousOrCritical, null, 2)).toEqual([]);
+    });
+  }
+});

--- a/tests/e2e/catalog.spec.ts
+++ b/tests/e2e/catalog.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Catalog', () => {
+  test('lists products and links each one to a details page', async ({ page }) => {
+    await page.goto('/catalogo');
+
+    const productLinks = page.locator('a.book-cover-container');
+    await expect(productLinks.first()).toBeVisible();
+    expect(await productLinks.count()).toBeGreaterThan(0);
+  });
+
+  test('the catalog still renders products when filter query params are present', async ({
+    page,
+  }) => {
+    // Characterization test only: today `type`/`level` query params do not
+    // actually scope which products render (see issue #56, "unify catalog
+    // filtering/sorting/URL state"). This just guards against the page
+    // crashing or rendering an empty grid for a filtered URL.
+    await page.goto('/catalogo?type=book&level=intermediate');
+
+    await expect(page.locator('a.book-cover-container').first()).toBeAttached();
+    expect(await page.locator('a.book-cover-container').count()).toBeGreaterThan(0);
+  });
+
+  test('opening a product card navigates to its details page', async ({ page }) => {
+    await page.goto('/catalogo');
+
+    const firstProduct = page.locator('a.book-cover-container').first();
+    const href = await firstProduct.getAttribute('href');
+    await firstProduct.click();
+
+    await expect(page).toHaveURL(new RegExp(href!.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+    await expect(page.locator('.add-to-cart-btn').first()).toBeVisible();
+  });
+});

--- a/tests/e2e/home.spec.ts
+++ b/tests/e2e/home.spec.ts
@@ -1,0 +1,18 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Home page', () => {
+  test('loads with the site title, nav and footer', async ({ page }) => {
+    await page.goto('/');
+
+    await expect(page).toHaveTitle(/FluentReads/i);
+    await expect(page.locator('nav')).toBeVisible();
+    await expect(page.locator('footer')).toBeVisible();
+  });
+
+  test('main nav links to the catalog and contact pages', async ({ page }) => {
+    await page.goto('/');
+
+    await expect(page.locator('nav a[href="/catalogo"]').first()).toBeVisible();
+    await expect(page.locator('nav a[href="/contacto"]').first()).toBeVisible();
+  });
+});

--- a/tests/e2e/purchase-flow.spec.ts
+++ b/tests/e2e/purchase-flow.spec.ts
@@ -1,0 +1,71 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Stub `window.open` so the WhatsApp handoff is verified by the URL the app
+ * builds, without actually navigating to wa.me (which redirects to
+ * api.whatsapp.com over the real network and is slow/flaky in CI).
+ */
+async function stubWindowOpen(page: import('@playwright/test').Page) {
+  await page.addInitScript(() => {
+    (window as unknown as { __openedUrls: string[] }).__openedUrls = [];
+    window.open = (url?: string | URL) => {
+      (window as unknown as { __openedUrls: string[] }).__openedUrls.push(String(url ?? ''));
+      return null;
+    };
+  });
+}
+
+test.describe('Catalog to WhatsApp checkout', () => {
+  test('adding a product to the cart carries its price through checkout and the WhatsApp message', async ({
+    page,
+  }) => {
+    await stubWindowOpen(page);
+
+    await page.goto('/catalogo');
+    await page.locator('a.book-cover-container').first().click();
+
+    const addToCartBtn = page.locator('.add-to-cart-btn').first();
+    await expect(addToCartBtn).toBeVisible();
+
+    const title = await addToCartBtn.getAttribute('data-title');
+    const price = Number(await addToCartBtn.getAttribute('data-price'));
+    expect(title).toBeTruthy();
+    expect(price).toBeGreaterThan(0);
+
+    await addToCartBtn.click();
+    await expect(page.locator('.cart-notification')).toBeVisible();
+
+    await page.goto('/checkout');
+    await expect(page.locator('#cart-items')).toContainText(title!);
+
+    const formattedTotal = `S/${price.toFixed(2)}`;
+    await expect(page.locator('#cart-total')).toHaveText(formattedTotal);
+
+    await page.locator('#whatsapp-checkout-btn').click();
+
+    const openedUrls = await page.evaluate(
+      () => (window as unknown as { __openedUrls: string[] }).__openedUrls
+    );
+    expect(openedUrls).toHaveLength(1);
+
+    const popupUrl = new URL(openedUrls[0]);
+    expect(popupUrl.hostname).toBe('wa.me');
+
+    const message = decodeURIComponent(popupUrl.search.replace('?text=', ''));
+    expect(message).toContain(title);
+    expect(message).toContain(formattedTotal);
+  });
+
+  test('removing the only item from the cart shows the empty-cart state', async ({ page }) => {
+    await page.goto('/catalogo');
+    await page.locator('a.book-cover-container').first().click();
+    await page.locator('.add-to-cart-btn').first().click();
+    await expect(page.locator('.cart-notification')).toBeVisible();
+
+    await page.goto('/checkout');
+    await page.locator('.remove-item').first().click();
+
+    await expect(page.locator('#empty-cart-message')).toBeVisible();
+    await expect(page.locator('#cart-container')).toBeHidden();
+  });
+});

--- a/tests/env.d.ts
+++ b/tests/env.d.ts
@@ -1,0 +1,5 @@
+// Ambient types for `bun:test` (describe/test/expect/mock) used across tests/.
+// Explicit reference because this project relies on automatic @types/*
+// inclusion for everything else, and bun-types' own module augmentation
+// isn't picked up reliably under moduleResolution "bundler".
+/// <reference types="bun-types" />

--- a/tests/unit/cartManager.test.ts
+++ b/tests/unit/cartManager.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, test, beforeEach } from 'bun:test';
+
+/**
+ * Bun's runtime does not provide `localStorage` outside a browser-like
+ * environment. CartManager only touches it inside static methods (never at
+ * module-load time), so a minimal in-memory polyfill installed before the
+ * tests run is enough to exercise the real implementation.
+ */
+class MemoryStorage implements Storage {
+  private store = new Map<string, string>();
+
+  get length(): number {
+    return this.store.size;
+  }
+
+  clear(): void {
+    this.store.clear();
+  }
+
+  getItem(key: string): string | null {
+    return this.store.has(key) ? this.store.get(key)! : null;
+  }
+
+  key(index: number): string | null {
+    return Array.from(this.store.keys())[index] ?? null;
+  }
+
+  removeItem(key: string): void {
+    this.store.delete(key);
+  }
+
+  setItem(key: string, value: string): void {
+    this.store.set(key, value);
+  }
+}
+
+(globalThis as unknown as { localStorage: Storage }).localStorage = new MemoryStorage();
+
+const { CartManager } = await import('../../src/utils/cartManager');
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('CartManager.getCart', () => {
+  test('returns an empty array when nothing has been stored', () => {
+    expect(CartManager.getCart()).toEqual([]);
+  });
+
+  test('returns an empty array when the stored value is corrupted JSON', () => {
+    localStorage.setItem('shoppingCart', '{not valid json');
+    expect(CartManager.getCart()).toEqual([]);
+  });
+});
+
+describe('CartManager.addItem', () => {
+  test('adds a new item with quantity 1', () => {
+    CartManager.addItem({ id: 'b1', title: 'Book 1', price: 10, image: '/i.jpg', type: 'book' });
+    expect(CartManager.getCart()).toEqual([
+      { id: 'b1', title: 'Book 1', price: 10, image: '/i.jpg', type: 'book', quantity: 1 },
+    ]);
+  });
+
+  test('increments quantity when the same id is added again', () => {
+    const item = { id: 'b1', title: 'Book 1', price: 10, image: '/i.jpg', type: 'book' as const };
+    CartManager.addItem(item);
+    CartManager.addItem(item);
+    const cart = CartManager.getCart();
+    expect(cart).toHaveLength(1);
+    expect(cart[0].quantity).toBe(2);
+  });
+
+  test('keeps distinct entries for different ids', () => {
+    CartManager.addItem({ id: 'b1', title: 'Book 1', price: 10, image: '/i.jpg', type: 'book' });
+    CartManager.addItem({ id: 'p1', title: 'Pack 1', price: 20, image: '/i.jpg', type: 'pack' });
+    expect(CartManager.getCart()).toHaveLength(2);
+  });
+});
+
+describe('CartManager.removeItem', () => {
+  test('removes only the targeted item', () => {
+    CartManager.addItem({ id: 'b1', title: 'Book 1', price: 10, image: '/i.jpg', type: 'book' });
+    CartManager.addItem({ id: 'b2', title: 'Book 2', price: 15, image: '/i.jpg', type: 'book' });
+    CartManager.removeItem('b1');
+    const cart = CartManager.getCart();
+    expect(cart).toHaveLength(1);
+    expect(cart[0].id).toBe('b2');
+  });
+});
+
+describe('CartManager.updateQuantity', () => {
+  test('updates the quantity of an existing item', () => {
+    CartManager.addItem({ id: 'b1', title: 'Book 1', price: 10, image: '/i.jpg', type: 'book' });
+    CartManager.updateQuantity('b1', 5);
+    expect(CartManager.getCart()[0].quantity).toBe(5);
+  });
+
+  test('ignores updates to a quantity below 1', () => {
+    CartManager.addItem({ id: 'b1', title: 'Book 1', price: 10, image: '/i.jpg', type: 'book' });
+    CartManager.updateQuantity('b1', 0);
+    expect(CartManager.getCart()[0].quantity).toBe(1);
+  });
+
+  test('is a no-op for an id that is not in the cart', () => {
+    CartManager.updateQuantity('missing', 3);
+    expect(CartManager.getCart()).toEqual([]);
+  });
+});
+
+describe('CartManager.clearCart', () => {
+  test('empties the cart', () => {
+    CartManager.addItem({ id: 'b1', title: 'Book 1', price: 10, image: '/i.jpg', type: 'book' });
+    CartManager.clearCart();
+    expect(CartManager.getCart()).toEqual([]);
+  });
+});
+
+describe('CartManager.getItemCount', () => {
+  test('sums quantities across all items', () => {
+    CartManager.addItem({ id: 'b1', title: 'Book 1', price: 10, image: '/i.jpg', type: 'book' });
+    CartManager.updateQuantity('b1', 3);
+    CartManager.addItem({ id: 'b2', title: 'Book 2', price: 10, image: '/i.jpg', type: 'book' });
+    expect(CartManager.getItemCount()).toBe(4);
+  });
+});
+
+describe('CartManager.getCartTotal', () => {
+  test('sums price * quantity across all items', () => {
+    CartManager.addItem({ id: 'b1', title: 'Book 1', price: 10, image: '/i.jpg', type: 'book' });
+    CartManager.updateQuantity('b1', 2);
+    CartManager.addItem({ id: 'b2', title: 'Book 2', price: 5, image: '/i.jpg', type: 'book' });
+    expect(CartManager.getCartTotal()).toBe(25);
+  });
+
+  test('returns 0 for an empty cart', () => {
+    expect(CartManager.getCartTotal()).toBe(0);
+  });
+});

--- a/tests/unit/catalogFilters.test.ts
+++ b/tests/unit/catalogFilters.test.ts
@@ -1,0 +1,225 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  filterProducts,
+  sortProducts,
+  processProducts,
+  getProductCounts,
+  getGridClassFromColumns,
+} from '../../src/utils/catalogFilters';
+import type { Product } from '../../src/types/product';
+
+function product(overrides: Partial<Product> = {}): Product {
+  return {
+    id: 'p1',
+    title: 'Sample Product',
+    description: 'A sample description',
+    price: 50,
+    coverImage: '/img.jpg',
+    formatTags: ['pdf'],
+    detailsLink: '/catalogo/libros/p1',
+    productType: 'book',
+    level: 'basic',
+    featured: false,
+    popularityTags: [],
+    ...overrides,
+  };
+}
+
+describe('filterProducts', () => {
+  const products = [
+    product({ id: 'b1', productType: 'book', level: 'basic', formatTags: ['pdf'] }),
+    product({ id: 'p1', productType: 'pack', level: 'advanced', formatTags: ['audio'] }),
+    product({ id: 'e1', productType: 'exam', level: 'intermediate', formatTags: ['video'] }),
+  ];
+
+  test('returns all products when filters are "any"/"all"', () => {
+    expect(filterProducts(products)).toHaveLength(3);
+  });
+
+  test('filters by resource type', () => {
+    const result = filterProducts(products, 'pack');
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('p1');
+  });
+
+  test('filters by level', () => {
+    const result = filterProducts(products, 'any', 'intermediate');
+    expect(result.map((p) => p.id)).toEqual(['e1']);
+  });
+
+  test('filters by format', () => {
+    const result = filterProducts(products, 'any', 'all', 'audio');
+    expect(result.map((p) => p.id)).toEqual(['p1']);
+  });
+
+  test('filters by search term matching the title', () => {
+    const result = filterProducts(
+      [
+        product({ id: 'x1', title: 'Grammar Essentials' }),
+        product({ id: 'x2', title: 'Vocabulary Boost' }),
+      ],
+      'any',
+      'all',
+      'all',
+      'grammar'
+    );
+    expect(result.map((p) => p.id)).toEqual(['x1']);
+  });
+
+  test('filters by search term matching the description', () => {
+    const result = filterProducts(
+      [
+        product({ id: 'x1', description: 'Great for IELTS prep' }),
+        product({ id: 'x2', description: 'General reading' }),
+      ],
+      'any',
+      'all',
+      'all',
+      'ielts'
+    );
+    expect(result.map((p) => p.id)).toEqual(['x1']);
+  });
+
+  test('filters by editorial name via the editorial map', () => {
+    const books = [
+      { ...product({ id: 'x1', title: 'Book One' }), editorialId: 'cambridge' } as Product,
+      { ...product({ id: 'x2', title: 'Book Two' }), editorialId: 'oxford' } as Product,
+    ];
+    const editorialMap = new Map([
+      ['cambridge', 'Cambridge University Press'],
+      ['oxford', 'Oxford Press'],
+    ]);
+
+    const result = filterProducts(books, 'any', 'all', 'all', 'cambridge', editorialMap);
+    expect(result.map((p) => p.id)).toEqual(['x1']);
+  });
+
+  test('combines multiple filters together', () => {
+    const result = filterProducts(products, 'book', 'basic');
+    expect(result.map((p) => p.id)).toEqual(['b1']);
+  });
+
+  test('returns an empty array when given no products', () => {
+    expect(filterProducts([])).toEqual([]);
+  });
+});
+
+describe('sortProducts', () => {
+  test('sorts by price ascending', () => {
+    const products = [
+      product({ id: 'a', price: 30 }),
+      product({ id: 'b', price: 10 }),
+      product({ id: 'c', price: 20 }),
+    ];
+    expect(sortProducts(products, 'price-low').map((p) => p.id)).toEqual(['b', 'c', 'a']);
+  });
+
+  test('sorts by price descending', () => {
+    const products = [
+      product({ id: 'a', price: 30 }),
+      product({ id: 'b', price: 10 }),
+      product({ id: 'c', price: 20 }),
+    ];
+    expect(sortProducts(products, 'price-high').map((p) => p.id)).toEqual(['a', 'c', 'b']);
+  });
+
+  test('sorts bestsellers first, tiebreaking by rating', () => {
+    const products = [
+      product({
+        id: 'low-rating-bestseller',
+        popularityTags: ['bestSeller'],
+        rating: { score: 3, reviewCount: 1 },
+      }),
+      product({ id: 'not-bestseller', rating: { score: 5, reviewCount: 1 } }),
+      product({
+        id: 'high-rating-bestseller',
+        popularityTags: ['bestSeller'],
+        rating: { score: 4.5, reviewCount: 1 },
+      }),
+    ];
+    expect(sortProducts(products, 'bestseller').map((p) => p.id)).toEqual([
+      'high-rating-bestseller',
+      'low-rating-bestseller',
+      'not-bestseller',
+    ]);
+  });
+
+  test('sorts featured first, bestseller as secondary criteria', () => {
+    const products = [
+      product({ id: 'plain' }),
+      product({ id: 'featured', featured: true }),
+      product({ id: 'bestseller', popularityTags: ['bestSeller'] }),
+    ];
+    expect(sortProducts(products, 'featured').map((p) => p.id)).toEqual([
+      'featured',
+      'bestseller',
+      'plain',
+    ]);
+  });
+
+  test('sorts alphabetically ascending and descending', () => {
+    const products = [product({ id: 'a', title: 'Banana' }), product({ id: 'b', title: 'Apple' })];
+    expect(sortProducts(products, 'name-asc').map((p) => p.id)).toEqual(['b', 'a']);
+    expect(sortProducts(products, 'name-desc').map((p) => p.id)).toEqual(['a', 'b']);
+  });
+
+  test('"newest" is a no-op today (no date field to sort by)', () => {
+    const products = [product({ id: 'a' }), product({ id: 'b' })];
+    expect(sortProducts(products, 'newest').map((p) => p.id)).toEqual(['a', 'b']);
+  });
+
+  test('returns an empty array when given no products', () => {
+    expect(sortProducts([], 'featured')).toEqual([]);
+  });
+});
+
+describe('processProducts', () => {
+  test('filters then sorts in a single call', () => {
+    const products = [
+      product({ id: 'a', productType: 'book', price: 30 }),
+      product({ id: 'b', productType: 'book', price: 10 }),
+      product({ id: 'c', productType: 'pack', price: 5 }),
+    ];
+
+    const result = processProducts(products, 'book', 'all', 'all', 'price-low');
+    expect(result.map((p) => p.id)).toEqual(['b', 'a']);
+  });
+});
+
+describe('getProductCounts', () => {
+  test('counts each product type plus a total', () => {
+    const products = [
+      product({ productType: 'book' }),
+      product({ productType: 'book' }),
+      product({ productType: 'pack' }),
+      product({ productType: 'exam' }),
+    ];
+    expect(getProductCounts(products)).toEqual({
+      totalCount: 4,
+      bookCount: 2,
+      packCount: 1,
+      examCount: 1,
+    });
+  });
+
+  test('returns all zeros for an empty list', () => {
+    expect(getProductCounts([])).toEqual({
+      totalCount: 0,
+      bookCount: 0,
+      packCount: 0,
+      examCount: 0,
+    });
+  });
+});
+
+describe('getGridClassFromColumns', () => {
+  test('returns the matching grid class for known column counts', () => {
+    expect(getGridClassFromColumns(3)).toBe('grid-cols-1 sm:grid-cols-2 lg:grid-cols-3');
+  });
+
+  test('falls back to a default class for unknown column counts', () => {
+    expect(getGridClassFromColumns(99)).toBe(
+      'grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4'
+    );
+  });
+});

--- a/tests/unit/catalogIntegrity.test.ts
+++ b/tests/unit/catalogIntegrity.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from 'bun:test';
+import books from '../../src/data/books.json';
+import packs from '../../src/data/packs.json';
+import exams from '../../src/data/exams.json';
+import editorial from '../../src/data/editorial.json';
+import offerHeroBanner from '../../src/data/offer-hero-banner.json';
+
+/**
+ * Characterization tests for the raw catalog JSON (pre-Content-Collections).
+ * CartManager and catalog lookups key products by `id` alone, so a duplicate
+ * id — even across different product types — silently merges unrelated
+ * products in the cart. These tests lock in the invariants the catalog
+ * currently satisfies; see issue #57 for making Content Collections the
+ * single source of truth and adding build-time versions of these checks.
+ */
+
+function idsOf(collection: { id: string }[]): string[] {
+  return collection.map((item) => item.id);
+}
+
+describe('catalog id uniqueness', () => {
+  test('book ids are unique', () => {
+    const ids = idsOf(books);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  test('pack ids are unique', () => {
+    const ids = idsOf(packs);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  test('exam ids are unique', () => {
+    const ids = idsOf(exams);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  test('no id is reused across different product types', () => {
+    const seen = new Map<string, string>();
+    const collisions: string[] = [];
+
+    for (const [type, collection] of [
+      ['book', books],
+      ['pack', packs],
+      ['exam', exams],
+    ] as const) {
+      for (const item of collection) {
+        const previousType = seen.get(item.id);
+        if (previousType && previousType !== type) {
+          collisions.push(`${item.id} (${previousType} vs ${type})`);
+        }
+        seen.set(item.id, type);
+      }
+    }
+
+    expect(collisions).toEqual([]);
+  });
+});
+
+describe('catalog cross-references', () => {
+  test('every book references an editorial that exists', () => {
+    const editorialIds = new Set(idsOf(editorial));
+    const missing = books.filter((book) => !editorialIds.has(book.editorialId)).map((b) => b.id);
+    expect(missing).toEqual([]);
+  });
+
+  test('the featured offer banner references an existing product of the declared type', () => {
+    const idsByType = {
+      book: new Set(idsOf(books)),
+      pack: new Set(idsOf(packs)),
+      exam: new Set(idsOf(exams)),
+    } as const;
+
+    const missing = offerHeroBanner
+      .filter((entry) => !idsByType[entry.type as keyof typeof idsByType]?.has(entry.id))
+      .map((entry) => `${entry.type}:${entry.id}`);
+
+    expect(missing).toEqual([]);
+  });
+});

--- a/tests/unit/checkoutMessage.test.ts
+++ b/tests/unit/checkoutMessage.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from 'bun:test';
+import { buildWhatsAppMessage, buildWhatsAppUrl } from '../../src/utils/checkoutMessage';
+import type { CartItem } from '../../src/utils/cartManager';
+
+function item(overrides: Partial<CartItem> = {}): CartItem {
+  return {
+    id: 'essential-grammar-advanced',
+    title: 'Essential Grammar Advanced',
+    price: 39.99,
+    image: '/img.jpg',
+    type: 'book',
+    quantity: 1,
+    ...overrides,
+  };
+}
+
+describe('buildWhatsAppMessage', () => {
+  test('lists every cart item with quantity and line total', () => {
+    const cart = [
+      item({ title: 'Book A', price: 10, quantity: 2 }),
+      item({ title: 'Book B', price: 5, quantity: 1 }),
+    ];
+
+    const message = buildWhatsAppMessage(cart, 25);
+
+    expect(message).toContain('1. Book A (2x) - S/20.00');
+    expect(message).toContain('2. Book B (1x) - S/5.00');
+  });
+
+  test('includes the header and total footer', () => {
+    const message = buildWhatsAppMessage([item({ price: 10, quantity: 1 })], 10);
+
+    expect(message).toStartWith('*Nuevo pedido desde FluentReads*');
+    expect(message).toContain('*Total: S/10.00*');
+    expect(message).toContain('Por favor, confirmame este pedido');
+  });
+
+  test('produces just the header/total when the cart is empty', () => {
+    const message = buildWhatsAppMessage([], 0);
+
+    expect(message).toContain('*Productos:*');
+    expect(message).toContain('*Total: S/0.00*');
+  });
+});
+
+describe('buildWhatsAppUrl', () => {
+  test('builds a wa.me link with the phone number', () => {
+    const url = buildWhatsAppUrl('51987654321', 'hola');
+    expect(url).toStartWith('https://wa.me/51987654321?text=');
+  });
+
+  test('URL-encodes special characters and line breaks in the message', () => {
+    const message = 'Línea 1\n*Total: S/10.00*';
+    const url = buildWhatsAppUrl('51987654321', message);
+
+    expect(url).toBe(`https://wa.me/51987654321?text=${encodeURIComponent(message)}`);
+    // Raw newlines/asterisks must not leak unescaped into the URL.
+    expect(url).not.toContain('\n');
+  });
+});

--- a/tests/unit/packsUtils.test.ts
+++ b/tests/unit/packsUtils.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, test } from 'bun:test';
+import { filterPacks, sortPacks, getFilteredPageTitle } from '../../src/utils/packsUtils';
+import type { Pack } from '../../src/types/pack';
+
+function pack(overrides: Partial<Pack> = {}): Pack {
+  return {
+    id: 'pack-1',
+    title: 'Sample Pack',
+    description: 'A sample pack',
+    price: 100,
+    coverImage: '/img.jpg',
+    booksIds: [],
+    includedItems: [],
+    detailsLink: '/catalogo/packs/pack-1',
+    buyLink: '/checkout',
+    level: 'basic',
+    formatTags: [],
+    popularityTags: [],
+    featured: false,
+    ...overrides,
+  };
+}
+
+describe('filterPacks', () => {
+  const packs = [
+    pack({ id: 'a', level: 'basic', formatTags: ['pdf'] }),
+    pack({ id: 'b', level: 'advanced', formatTags: ['audio'] }),
+  ];
+
+  test('returns all packs when filters are "all"', () => {
+    expect(filterPacks(packs, 'all', 'all')).toHaveLength(2);
+  });
+
+  test('filters by level', () => {
+    expect(filterPacks(packs, 'advanced', 'all').map((p) => p.id)).toEqual(['b']);
+  });
+
+  test('filters by format', () => {
+    expect(filterPacks(packs, 'all', 'pdf').map((p) => p.id)).toEqual(['a']);
+  });
+
+  test('combines level and format filters', () => {
+    expect(filterPacks(packs, 'basic', 'pdf').map((p) => p.id)).toEqual(['a']);
+    expect(filterPacks(packs, 'basic', 'audio')).toEqual([]);
+  });
+});
+
+describe('sortPacks', () => {
+  test('sorts by price ascending/descending', () => {
+    const packs = [pack({ id: 'a', price: 30 }), pack({ id: 'b', price: 10 })];
+    expect(sortPacks(packs, 'price-low').map((p) => p.id)).toEqual(['b', 'a']);
+    expect(sortPacks(packs, 'price-high').map((p) => p.id)).toEqual(['a', 'b']);
+  });
+
+  test('sorts bestsellers first', () => {
+    const packs = [pack({ id: 'a' }), pack({ id: 'b', popularityTags: ['bestSeller'] })];
+    expect(sortPacks(packs, 'bestseller').map((p) => p.id)).toEqual(['b', 'a']);
+  });
+
+  test('sorts by book count descending', () => {
+    const packs = [
+      pack({ id: 'small', booksIds: ['x'] }),
+      pack({ id: 'large', booksIds: ['x', 'y', 'z'] }),
+    ];
+    expect(sortPacks(packs, 'book-count').map((p) => p.id)).toEqual(['large', 'small']);
+  });
+
+  test('sorts featured first by default', () => {
+    const packs = [pack({ id: 'plain' }), pack({ id: 'featured', featured: true })];
+    expect(sortPacks(packs, 'featured').map((p) => p.id)).toEqual(['featured', 'plain']);
+  });
+});
+
+describe('getFilteredPageTitle', () => {
+  const site = 'https://fluentreads.com';
+
+  test('returns the default title/description when no filters are active', () => {
+    const result = getFilteredPageTitle({
+      level: 'all',
+      format: 'all',
+      baseUrl: '/catalogo/packs',
+      site,
+    });
+    expect(result.pageTitle).toBe('Packs de Libros en Inglés');
+    expect(result.canonicalUrl).toBe('https://fluentreads.com/catalogo/packs');
+  });
+
+  test('customizes the title/canonical URL for a level filter', () => {
+    const result = getFilteredPageTitle({
+      level: 'advanced',
+      format: 'all',
+      baseUrl: '/catalogo/packs',
+      site,
+    });
+    expect(result.pageTitle).toContain('Avanzado');
+    expect(result.canonicalUrl).toBe('https://fluentreads.com/catalogo/packs?level=advanced');
+  });
+
+  test('combines level and format customization', () => {
+    const result = getFilteredPageTitle({
+      level: 'basic',
+      format: 'audio',
+      baseUrl: '/catalogo/packs',
+      site,
+    });
+    expect(result.pageTitle).toBe('Material con Audio - Packs de Libros - Básico');
+  });
+});

--- a/tests/unit/pricing.test.ts
+++ b/tests/unit/pricing.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from 'bun:test';
+import { calculateDiscountedPrice, formatPEN } from '../../src/utils/pricing';
+
+describe('calculateDiscountedPrice', () => {
+  test('returns the original price when there is no discount', () => {
+    expect(calculateDiscountedPrice(100, 0)).toBe(100);
+  });
+
+  test('returns the original price when discount is undefined', () => {
+    expect(calculateDiscountedPrice(100)).toBe(100);
+  });
+
+  test('applies a partial discount correctly', () => {
+    expect(calculateDiscountedPrice(100, 25)).toBeCloseTo(75, 5);
+  });
+
+  test('applies a full 100% discount down to zero', () => {
+    expect(calculateDiscountedPrice(50, 100)).toBe(0);
+  });
+
+  test('ignores negative discounts and returns the original price', () => {
+    expect(calculateDiscountedPrice(100, -10)).toBe(100);
+  });
+
+  test('matches the previous inline formula used by product cards', () => {
+    const price = 39.99;
+    const discount = 15;
+    const expected = price * (1 - discount / 100);
+    expect(calculateDiscountedPrice(price, discount)).toBeCloseTo(expected, 10);
+  });
+});
+
+describe('formatPEN', () => {
+  test('formats whole numbers with two decimals and the S/ prefix', () => {
+    expect(formatPEN(100)).toBe('S/100.00');
+  });
+
+  test('rounds to two decimals', () => {
+    expect(formatPEN(19.995)).toBe('S/20.00');
+  });
+
+  test('formats zero correctly', () => {
+    expect(formatPEN(0)).toBe('S/0.00');
+  });
+});


### PR DESCRIPTION
## Summary

Resolves #51 (scoped to the minimum viable coverage below; see "Deferred" section).

- Adds `bun:test` unit coverage (65 tests) for:
  - Discount/effective price math (`src/utils/pricing.ts`, newly extracted)
  - Catalog filter/sort/process/count logic (`catalogFilters.ts`)
  - Pack filter/sort/page-title logic (`packsUtils.ts`)
  - `CartManager` add/remove/update/clear/count/total, including corrupted-localStorage handling
  - WhatsApp checkout message + wa.me URL builder (`src/utils/checkoutMessage.ts`, newly extracted)
  - Cross-collection catalog integrity: unique ids (including cross-type collisions, which matter because `CartManager` keys by id alone), editorial references, featured-banner references
- Adds a Playwright E2E smoke suite (9 tests) covering: home nav, catalog listing, product → details → add-to-cart → checkout → WhatsApp handoff (message content + total verified), cart item removal, and an axe accessibility baseline (serious/critical only) on `/` and `/catalogo`.
- New scripts: `bun run test:unit`, `bun run test:e2e`, `bun run test` (alias for unit).
- CI: new `test` (unit) and `test-e2e` (Playwright, `--with-deps chromium`) jobs in `ci.yml`.
- Extracted `calculateDiscountedPrice`/`formatPEN` and `buildWhatsAppMessage`/`buildWhatsAppUrl` out of duplicated inline formulas in `ProductCard.astro`/`Card.astro`/`checkout.astro` — behavior-preserving, done purely to make this logic unit-testable.

### Accessibility fixes found by the new axe checks

The new a11y baseline test caught two real, pre-existing issues, fixed here since the test suite can't be green otherwise:
- Insufficient color contrast (1.74:1 and 3.51:1, need 4.5:1) on category card CTAs and the footer newsletter input — both fixed with existing theme tokens already proven compliant elsewhere in the same components.
- Nested interactive controls on home page product cards: an outer `role="button" tabindex="0"` wrapped real `<a>`/`<button>` children. Removed the redundant role/tabindex (mobile tap-to-expand still works as a plain click listener); the real controls already handle keyboard/screen-reader interaction.

### Deferred (out of scope for this PR)

- Full Playwright coverage of every flow listed in #51 (contact form, newsletter, legal pages, keyboard nav audit, etc.) — this PR covers the core conversion path (catalog → cart → WhatsApp) plus a11y/home/catalog smoke tests as a foundation.
- `tests/unit/catalogIntegrity.test.ts` intentionally does **not** assert `packs[].booksIds` reference existing books — the current catalog data has 10 dangling references (packs pointing at books that don't exist yet). That's real, pre-existing demo-data debt matching #53's description; fixing it belongs there, not in a test-infra PR. Filed as a note for that issue.
- `/catalogo?type=...&level=...` query params don't currently scope which products render (confirmed while writing `tests/e2e/catalog.spec.ts` — the test only asserts the page still renders, not that it filters). This matches #56's premise; left as characterization, not fixed here.
- Only the unit `test` job is added to required status checks (alongside the existing `lint`/`check`/`build`); `test-e2e` runs in CI but isn't required yet, since browser-based E2E is more prone to environmental flakiness than a solo-maintained repo's merge gate should depend on. Can revisit once it's proven stable over a few weeks.

## Test plan

- [x] `bun run format:check` — clean
- [x] `bun run lint` — 0 errors (130 pre-existing warnings, unchanged baseline)
- [x] `bun run check` — 0 errors/0 warnings/1 pre-existing hint
- [x] `bun run test:unit` — 65/65 pass
- [x] `bun run build` — 29 pages, succeeds
- [x] `bun run test:e2e` — 9/9 pass, run twice to check for flakiness (stable both times)
- [x] Verified `ASTRO_DEV_BACKGROUND=0` is needed in `playwright.config.ts`'s `webServer.env` — Astro 7 auto-backgrounds `astro dev` when it detects an AI coding agent, which orphans the process Playwright manages; without this the E2E run fails with "Process from config.webServer exited early"