### PR TITLE
fix(cms): align Decap CMS publishing with main and remove stale integrations

### DIFF
--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -1,7 +1,11 @@
 backend:
   name: github
   repo: sandovaldavid/fluentreads
-  branch: feat/b9-decap-cms
+  branch: main
+# main requires a pull request + passing lint/check/build status checks
+# (see repo ruleset), so edits must go through a PR rather than a direct
+# push straight to the protected branch.
+publish_mode: editorial_workflow
 local_backend: true
 media_folder: public/images
 public_folder: /images

--- a/public/admin/index.html
+++ b/public/admin/index.html
@@ -227,11 +227,13 @@
                     ) {
                       setReactInputValue(detailsLinkInput, `/catalogo/${category}/${slug}`);
                     }
+                    // El checkout actual es una sola página basada en carrito
+                    // (localStorage), no una ruta por producto.
                     if (
                       buyLinkInput &&
-                      (!buyLinkInput.value || buyLinkInput.value.includes('/checkout/'))
+                      (!buyLinkInput.value || buyLinkInput.value.startsWith('/checkout/'))
                     ) {
-                      setReactInputValue(buyLinkInput, `/checkout/${slug}`);
+                      setReactInputValue(buyLinkInput, '/checkout');
                     }
                   }
                 });
@@ -244,10 +246,14 @@
       }
     </script>
 
-    <!-- Incluye el script de Decap CMS de forma nativa desde unpkg -->
-    <script src="https://unpkg.com/decap-cms@^3.0.0/dist/decap-cms.js"></script>
-    <!-- Integración con Cloudinary Media Library -->
-    <script src="https://unpkg.com/decap-cms-media-library-cloudinary@^1.3.0/dist/decap-cms-media-library-cloudinary.js"></script>
+    <!-- Incluye el script de Decap CMS de forma nativa desde unpkg. Versión
+         exacta (no rango) + SRI por reproducibilidad y para detectar si el
+         CDN sirviera un archivo distinto al esperado. -->
+    <script
+      src="https://unpkg.com/decap-cms@3.15.1/dist/decap-cms.js"
+      integrity="sha384-in6eHztHveqQ7uMZ1fDaKlDmacQLFuLH2wWrFTiymyuS8zQ5bixwL8U3AeRi8h/L"
+      crossorigin="anonymous"
+    ></script>
     <script>
       // Detectar si estamos en desarrollo local
       const isLocal =


### PR DESCRIPTION
## Summary

Resolves #52 (scoped to the concrete, low-risk fixes below; see "Deferred").

- `config.yml` pointed at `feat/b9-decap-cms`, a leftover one-off branch. Points it at `main` now, per the chosen governance model: single branch, single pre-release flow on `main` (release-please already only runs on `main`, confirmed by checking `release-please.yml`/history — this just aligns the CMS with that).
- Added `publish_mode: editorial_workflow`: `main`'s ruleset requires a PR plus passing `lint`/`check`/`build` status checks, so Decap's default direct-push ("simple") mode would just be rejected. Editorial workflow makes it open a PR instead, which then goes through the same required checks as any other change.
- Pinned the Decap CMS `<script>` to the exact version already being served (`3.15.1`, verified via `unpkg`) with SRI, instead of a floating `^3.0.0` range.
- Removed the Cloudinary media library `<script>` tag: it requested `decap-cms-media-library-cloudinary@^1.3.0`, a range with **no matching published version** (confirmed 404 from unpkg — `1.4.0-beta.0` jumps straight to `3.0.0`+ on npm), and there's no `media_library:` config block activating it anyway. It was dead weight either way.
- Fixed the CMS's `buyLink` autogeneration: it produced `/checkout/<slug>`, but checkout is a single cart-based page (`/checkout`), not a per-product route. Confirmed `buyLink` isn't rendered as an `href` anywhere in the app today, so this only affects new CMS entries going forward — not a live bug.

## Deferred (out of scope for this PR)

- The fetch-interceptor / `MutationObserver` React-input-hacking approach in `index.html` is fragile (per #52's own description) but currently functional. Rewriting it to use documented Decap widgets/extension points instead is a larger, higher-risk change I can't fully verify without a live GitHub OAuth session, so it's left as-is.
- A real Cloudinary media library needs actual Cloudinary account credentials — same class of blocker as #53 (can't fabricate real third-party config). Re-adding it properly is a follow-up once those credentials exist.
- Full round-trip verification (create/edit an entry through the real Decap UI, confirm the PR it opens passes CI) requires GitHub OAuth and isn't something I can drive headlessly here. Validated statically instead: YAML syntax, that `astro build` copies the updated `public/admin/` through to `dist/admin/` correctly, and that the referenced script URLs resolve (200) with the right SRI hash.

## Test plan

- [x] `bun run format:check` / `lint` / `check` / `build` — all clean (0 errors, same warning baseline as develop)
- [x] `python3 -c "import yaml; yaml.safe_load(open('public/admin/config.yml'))"` — valid YAML
- [x] Verified `dist/admin/config.yml` and `dist/admin/index.html` reflect the changes after `bun run build`
- [x] Verified `https://unpkg.com/decap-cms@3.15.1/dist/decap-cms.js` resolves 200 with CORS headers (required for SRI + `crossorigin="anonymous"`) and matches the computed SRI hash
- [x] Verified the old Cloudinary script URL 404s (confirms it was already broken, this isn't a regression)