### PR TITLE
ci(release): restore meaningful develop/main deployment governance

### DIFF
--- a/.github/workflows/deploy-vercel.yml
+++ b/.github/workflows/deploy-vercel.yml
@@ -13,6 +13,10 @@ jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
+    # Without a timeout, a misconfigured Vercel CLI call (e.g. missing
+    # org/project id) prompts interactively and hangs for the GitHub Actions
+    # default of 6h on every single push instead of failing fast.
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -27,6 +31,17 @@ jobs:
 
       - name: Build
         run: bun run build
+
+      - name: Verify Vercel secrets are configured
+        run: |
+          missing=()
+          [ -z "${{ secrets.VERCEL_TOKEN }}" ] && missing+=("VERCEL_TOKEN")
+          [ -z "${{ secrets.VERCEL_ORG_ID }}" ] && missing+=("VERCEL_ORG_ID")
+          [ -z "${{ secrets.VERCEL_PROJECT_ID }}" ] && missing+=("VERCEL_PROJECT_ID")
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo "::error::Missing repo secrets: ${missing[*]}. Without vercel-org-id/vercel-project-id the Vercel CLI prompts interactively and this job hangs until the timeout instead of deploying. Get these from 'vercel link' locally or the Vercel dashboard (Project Settings > General), then add them under Settings > Secrets and variables > Actions."
+            exit 1
+          fi
 
       - name: Deploy Preview (develop)
         if: github.ref == 'refs/heads/develop'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,6 +69,18 @@ Antes de crear un commit o un Pull Request, te sugerimos correr los checks local
 bun run lint             # Verifica errores de ESLint
 bun run check            # Verifica tipado de TypeScript y archivos .astro (Type-check)
 bun run build            # Realiza el build del proyecto asegurando que todo compila
+bun run test:unit        # Corre la suite de pruebas unitarias (bun:test)
+bun run test:e2e         # Corre la suite E2E de Playwright (requiere navegador instalado)
 ```
+
+## Despliegue y Rollback
+
+- `develop` → Vercel Preview. `main` → Vercel Producción. Ambos se despliegan desde el workflow `deploy-vercel.yml` (GitHub Actions); el Git integration nativo de Vercel está deshabilitado para que un mismo commit no se despliegue dos veces por dos mecanismos distintos.
+- `release-please` corre únicamente en `main`: cada merge de su PR de release publica un GitHub Release y un tag `vX.Y.Z`.
+- `main` no admite force-push ni borrado (bloqueado por ruleset), así que el rollback de producción se hace revirtiendo commits, no reescribiendo historial:
+  1. Ubica el último commit bueno: `git log --oneline origin/main`.
+  2. Revierte el/los commits problemáticos en una rama nueva: `git revert <sha-malo>` (o `git revert -m 1 <sha-merge>` si es un merge commit).
+  3. Abre un PR normal hacia `main` con el revert; debe pasar `lint`/`check`/`build` como cualquier otro cambio.
+  4. Al mergear, `Deploy to Vercel` publica la versión revertida automáticamente, y el siguiente release de `release-please` reflejará el revert en el changelog.
 
 ¡Gracias por ayudar a construir FluentReads!


### PR DESCRIPTION
## Summary

Partial fix for #63 — the governance model itself (single branch/pre-release on `main`, PR + status checks required on both branches) turned out to already be in place from earlier work; this PR fixes what was actually broken/missing.

### Real bug found and fixed (partially)

Every single `Deploy to Vercel` run — on every push to `develop` and `main`, going back through the last 10+ runs I checked — hangs `in_progress` for the full 6-hour GitHub Actions default timeout before being auto-cancelled. `gh secret list` shows only `VERCEL_TOKEN` is configured; `VERCEL_ORG_ID` and `VERCEL_PROJECT_ID` are missing. Without those, the Vercel CLI can't determine which org/project to deploy to and hangs on an interactive prompt that never resolves in a non-TTY CI environment.

**I can't fully fix this** — I don't have a way to look up or invent the real `VERCEL_ORG_ID`/`VERCEL_PROJECT_ID` values. What this PR does instead:
- `timeout-minutes: 10` on the deploy job, so this fails in minutes instead of silently burning 6h of Actions compute on every push.
- A "Verify Vercel secrets are configured" step that fails immediately with a clear, actionable message if any of the three secrets are missing, instead of the current opaque hang.

**Action needed from you**: run `vercel link` locally (or check the Vercel dashboard → Project Settings → General) to get the org ID and project ID, then add them as `VERCEL_ORG_ID` / `VERCEL_PROJECT_ID` under repo Settings → Secrets and variables → Actions. Until then, deploys will keep failing fast with a clear error instead of hanging.

### Confirmed already correct (no changes needed)

- `release-please.yml` already targets only `main` (`target-branch: main`), matching "single pre-release flow on main."
- Both `develop` and `main` rulesets already require a PR (no direct pushes) plus passing `lint`/`check`/`build` status checks (verified via `gh api repos/.../rulesets`).
- `vercel.json` / earlier PRs (#31) already disabled Vercel's native Git integration, so GitHub Actions is the single deploy mechanism per branch — no double-deploy risk.

### Documentation

Added a "Despliegue y Rollback" section to `CONTRIBUTING.md`: which branch deploys where, that release-please only runs on `main`, and the revert-based rollback procedure (`main` blocks force-push, so rollback = revert commit + normal PR, not history rewriting). Also added the `test:unit`/`test:e2e` commands from #51 that were missing from the "Comandos Útiles" list.

## Deferred (out of scope here)

- Actually restoring working deploys (needs the real `VERCEL_ORG_ID`/`VERCEL_PROJECT_ID` — see above).
- Broader README/AGENTS.md doc sync — that's #64's scope; this PR only touches CONTRIBUTING.md's deploy section since it's an explicit #63 acceptance criterion.

## Test plan

- [x] `bun run format:check` / `lint` / `check` / `build` — all clean
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/deploy-vercel.yml'))"` — valid YAML
- [x] Confirmed the hang via `gh run list --workflow="Deploy to Vercel"` (10 consecutive runs, all `in_progress` → `cancelled` at ~6h)
- [x] Confirmed root cause via `gh secret list` (only `VERCEL_TOKEN` present)
- [x] Confirmed via `gh api repos/.../rulesets/...` that both branch rulesets already require PR + lint/check/build