### PR TITLE
fix(forms): make contact and newsletter submissions reliable

### DIFF
--- a/src/components/CTA-Banner.astro
+++ b/src/components/CTA-Banner.astro
@@ -1,6 +1,9 @@
 ---
-const pageclipKey = import.meta.env.PUBLIC_PAGECLIP_KEY || '';
-const actionUrl = `https://send.pageclip.co/${pageclipKey}/newsletter`;
+const pageclipKey = import.meta.env.PUBLIC_PAGECLIP_KEY;
+const isNewsletterConfigured = !!pageclipKey;
+const actionUrl = isNewsletterConfigured
+  ? `https://send.pageclip.co/${pageclipKey}/newsletter`
+  : '#';
 import EmailIcon from './icons/Email.astro';
 import BookIcon from './icons/Book.astro';
 import HandshakeIcon from './icons/Handshake.astro';
@@ -81,27 +84,37 @@ const currentCta = ctaConfig[type];
       <div class="flex-shrink-0">
         {
           type === 'newsletter' ? (
-            <form
-              id="newsletter-form"
-              action={actionUrl}
-              method="POST"
-              class="flex flex-col items-center gap-3 sm:flex-row"
-            >
-              <input
-                type="email"
-                name="email"
-                placeholder="Tu correo electrónico"
-                class="rounded-lg border-2 border-white/30 bg-white/10 px-4 py-3 text-white placeholder:text-white/70 focus:border-white focus:outline-none"
-                aria-label="Correo electrónico para boletín informativo"
-                required
-              />
-              <button
-                type="submit"
-                class="text-primary-dark hover:bg-neutral-light rounded-lg bg-white px-6 py-3 font-bold shadow-md transition-colors"
+            <div>
+              <form
+                id="newsletter-form"
+                action={actionUrl}
+                method="POST"
+                class="flex flex-col items-center gap-3 sm:flex-row"
               >
-                {currentCta.buttonText}
-              </button>
-            </form>
+                <input
+                  type="email"
+                  name="email"
+                  placeholder="Tu correo electrónico"
+                  class="rounded-lg border-2 border-white/30 bg-white/10 px-4 py-3 text-white placeholder:text-white/70 focus:border-white focus:outline-none disabled:opacity-50"
+                  aria-label="Correo electrónico para boletín informativo"
+                  disabled={!isNewsletterConfigured}
+                  required
+                />
+                <button
+                  type="submit"
+                  class="text-primary-dark hover:bg-neutral-light cursor-pointer rounded-lg bg-white px-6 py-3 font-bold shadow-md transition-colors disabled:cursor-not-allowed disabled:opacity-50"
+                  disabled={!isNewsletterConfigured}
+                >
+                  {currentCta.buttonText}
+                </button>
+              </form>
+              <p
+                id="newsletter-form-message"
+                class="mt-2 hidden text-center text-sm text-white sm:text-left"
+                role="status"
+                aria-live="polite"
+              />
+            </div>
           ) : (
             <a
               href={currentCta.buttonLink}
@@ -117,38 +130,9 @@ const currentCta = ctaConfig[type];
 </div>
 
 <script>
-  // Newsletter form handling
+  import { initNewsletterForm } from '@utils/newsletterForm';
+
   document.addEventListener('DOMContentLoaded', () => {
-    const newsletterForm = document.getElementById('newsletter-form') as HTMLFormElement | null;
-    if (newsletterForm) {
-      newsletterForm.addEventListener('submit', (e) => {
-        e.preventDefault();
-        const emailInput = newsletterForm.querySelector(
-          "input[name='email']"
-        ) as HTMLInputElement | null;
-        if (emailInput && emailInput.value) {
-          fetch(newsletterForm.action, {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-              Accept: 'application/json',
-            },
-            body: JSON.stringify({ email: emailInput.value }),
-          })
-            .then((res) => {
-              if (res.ok) {
-                alert('¡Gracias por suscribirte! Pronto recibirás nuestras novedades.');
-                newsletterForm.reset();
-              } else {
-                throw new Error('Error en el servidor');
-              }
-            })
-            .catch((err) => {
-              console.error('Error newsletter signup:', err);
-              alert('Hubo un error al procesar tu suscripción. Por favor, inténtalo de nuevo.');
-            });
-        }
-      });
-    }
+    initNewsletterForm({ formId: 'newsletter-form', messageId: 'newsletter-form-message' });
   });
 </script>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,6 +1,9 @@
 ---
-const pageclipKey = import.meta.env.PUBLIC_PAGECLIP_KEY || '';
-const actionUrl = `https://send.pageclip.co/${pageclipKey}/newsletter`;
+const pageclipKey = import.meta.env.PUBLIC_PAGECLIP_KEY;
+const isNewsletterConfigured = !!pageclipKey;
+const actionUrl = isNewsletterConfigured
+  ? `https://send.pageclip.co/${pageclipKey}/newsletter`
+  : '#';
 import SocialMediaContent from './SocialMediaContent.astro';
 import Button from './Button.astro';
 import '../styles/Footer.css';
@@ -88,19 +91,28 @@ const footerLinks = [
               type="email"
               name="email"
               placeholder="Tu correo electrónico"
-              class="focus:ring-secondary bg-primary-dark min-h-11 min-w-0 flex-grow rounded-full px-4 py-2 text-sm text-white focus:ring-2 focus:outline-none md:py-3 md:text-base"
+              class="focus:ring-secondary bg-primary-dark min-h-11 min-w-0 flex-grow rounded-full px-4 py-2 text-sm text-white focus:ring-2 focus:outline-none disabled:opacity-50 md:py-3 md:text-base"
               aria-label="Correo electrónico para boletín informativo"
+              disabled={!isNewsletterConfigured}
               required
             />
             <Button
               variant="secondary"
               type="submit"
               size="small"
-              class="md:size-medium transform whitespace-nowrap shadow-md transition-all duration-300 hover:shadow-lg"
+              class="md:size-medium transform cursor-pointer whitespace-nowrap shadow-md transition-all duration-300 hover:shadow-lg disabled:cursor-not-allowed disabled:opacity-50"
+              disabled={!isNewsletterConfigured}
             >
               Suscribirse
             </Button>
           </form>
+          <p
+            id="footer-newsletter-message"
+            class="mt-2 hidden text-xs"
+            role="status"
+            aria-live="polite"
+          >
+          </p>
           <p class="text-neutral-light mt-2 text-xs md:mt-3">
             Al suscribirte, aceptas nuestra <a
               href="/politica-privacidad"
@@ -147,35 +159,12 @@ const footerLinks = [
 </footer>
 
 <script>
-  document.addEventListener('DOMContentLoaded', () => {
-    const form = document.getElementById('footer-newsletter-form') as HTMLFormElement | null;
-    if (form) {
-      form.addEventListener('submit', (e) => {
-        e.preventDefault();
-        const emailInput = form.querySelector("input[name='email']") as HTMLInputElement | null;
-        if (!emailInput || !emailInput.value) return;
+  import { initNewsletterForm } from '@utils/newsletterForm';
 
-        fetch(form.action, {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            Accept: 'application/json',
-          },
-          body: JSON.stringify({ email: emailInput.value }),
-        })
-          .then((res) => {
-            if (res.ok) {
-              alert('¡Gracias por suscribirte! Pronto recibirás nuestras novedades.');
-              form.reset();
-            } else {
-              throw new Error('Error en el servidor');
-            }
-          })
-          .catch((err) => {
-            console.error('Error newsletter signup:', err);
-            alert('Hubo un error al procesar tu suscripción. Por favor, inténtalo de nuevo.');
-          });
-      });
-    }
+  document.addEventListener('DOMContentLoaded', () => {
+    initNewsletterForm({
+      formId: 'footer-newsletter-form',
+      messageId: 'footer-newsletter-message',
+    });
   });
 </script>

--- a/src/components/contact/Form.astro
+++ b/src/components/contact/Form.astro
@@ -21,18 +21,15 @@ interface FormField {
   errorMessage: string;
 }
 
-// Environment variables configuration supporting both client (PUBLIC_) and server scopes (Issues 5, 11)
-const pageclipKey = import.meta.env.PUBLIC_PAGECLIP_KEY || import.meta.env.PAGECLIP_KEY;
-const isDevelopment =
-  import.meta.env.PUBLIC_IS_DEVELOPMENT === 'true' || import.meta.env.IS_DEVELOPMENT === 'true';
+// This is a static site: all env vars read here run at build time, so only
+// the PUBLIC_-prefixed names are used (single canonical name per value,
+// matching the static-first model instead of a confusing fallback chain).
+const pageclipKey = import.meta.env.PUBLIC_PAGECLIP_KEY;
+const isDevelopment = import.meta.env.PUBLIC_IS_DEVELOPMENT === 'true';
 
 // In development mode, always disable reCAPTCHA to avoid COEP errors
-const enableRecaptcha = isDevelopment
-  ? false
-  : import.meta.env.PUBLIC_ENABLE_RECAPTCHA !== 'false' &&
-    import.meta.env.ENABLE_RECAPTCHA !== 'false';
-const recaptchaSiteKey =
-  import.meta.env.PUBLIC_RECAPTCHA_SITE_KEY || import.meta.env.RECAPTCHA_SITE_KEY;
+const enableRecaptcha = isDevelopment ? false : import.meta.env.PUBLIC_ENABLE_RECAPTCHA !== 'false';
+const recaptchaSiteKey = import.meta.env.PUBLIC_RECAPTCHA_SITE_KEY;
 
 // Configure form with environment variables (Issue 6)
 const isConfigured = !!pageclipKey;
@@ -296,6 +293,21 @@ const contactForm = {
         )
       }
 
+      <!-- Inline, non-blocking feedback for submission-level errors (replaces alert()) -->
+      <div
+        id="form-error-banner"
+        class="hidden border-l-4 border-red-500 bg-red-50 p-4"
+        role="alert"
+        aria-live="polite"
+      >
+        <div class="flex">
+          <div class="flex-shrink-0">
+            <WarningIcon class="h-5 w-5 text-red-500" />
+          </div>
+          <p id="form-error-banner-text" class="ml-3 text-sm text-red-700"></p>
+        </div>
+      </div>
+
       <!-- Submit Button with loading state -->
       <div class="flex justify-end">
         <!-- Corregido: Estructura del botón para mostrar correctamente el texto -->
@@ -334,19 +346,14 @@ const contactForm = {
 <script
   is:inline
   define:vars={{
-    siteKey: contactForm.recaptcha.siteKey,
     isDevelopment: contactForm.recaptcha.isDevelopment,
     enabled: contactForm.recaptcha.enabled,
   }}
 >
   if (!isDevelopment && enabled) {
-    // Log reCAPTCHA parameters to console
-    console.log('Client-side reCAPTCHA check - Site key:', siteKey);
-
     // Function to initialize reCAPTCHA
     function initRecaptcha() {
       if (typeof grecaptcha !== 'undefined' && grecaptcha) {
-        console.log('reCAPTCHA API loaded successfully');
         // Nothing needed here - the API will render automatically with the widget div
       } else {
         console.error('reCAPTCHA API not available');
@@ -376,13 +383,6 @@ const contactForm = {
 
 <script define:vars={{ contactForm }} is:inline>
   document.addEventListener('DOMContentLoaded', () => {
-    // Debug logging for client-side
-    console.log('Form initialized, reCAPTCHA enabled:', contactForm.recaptcha.enabled);
-    console.log('Development mode:', contactForm.recaptcha.isDevelopment);
-    if (contactForm.recaptcha.enabled) {
-      console.log('Using reCAPTCHA site key:', contactForm.recaptcha.siteKey);
-    }
-
     const form = document.getElementById('contactForm');
     const formContainer = document.getElementById('form-container');
     const responseContainer = document.getElementById('form-response-container');
@@ -391,37 +391,18 @@ const contactForm = {
     const submitButtonContent = submitButton.querySelector('.submit-button-content');
     const submitButtonLoading = submitButton.querySelector('.submit-button-loading');
     const formGroups = document.querySelectorAll('.form-group');
+    const errorBanner = document.getElementById('form-error-banner');
+    const errorBannerText = document.getElementById('form-error-banner-text');
 
-    // Track the submit event ourselves instead of relying on the deprecated global `event`
-    let currentSubmitEvent = null;
-    form.addEventListener('submit', (e) => {
-      currentSubmitEvent = e;
-    });
-
-    // Hide default Pageclip thank you page
-    // Esto asegura que el mensaje predeterminado de Pageclip se elimine del DOM
-    function hideDefaultPageclipMessage() {
-      const pageclipMessages = document.querySelectorAll('.pageclip-form__success');
-      pageclipMessages.forEach((message) => {
-        message.style.display = 'none';
-        message.remove();
-      });
+    function showFormError(message) {
+      if (!errorBanner || !errorBannerText) return;
+      errorBannerText.textContent = message;
+      errorBanner.classList.remove('hidden');
     }
 
-    // Override default pageclip success message
-    // Agregar un estilo para ocultar la página de agradecimiento predeterminada
-    const style = document.createElement('style');
-    style.textContent = `
-			.pageclip-form__success {
-				display: none !important;
-				visibility: hidden !important;
-				opacity: 0 !important;
-				height: 0 !important;
-				overflow: hidden !important;
-				pointer-events: none !important;
-			}
-		`;
-    document.head.appendChild(style);
+    function hideFormError() {
+      errorBanner?.classList.add('hidden');
+    }
 
     // Form validation function
     function validateField(input) {
@@ -466,21 +447,21 @@ const contactForm = {
           // Check if grecaptcha is available
           if (typeof grecaptcha === 'undefined') {
             console.error('reCAPTCHA not loaded');
-            alert('Error: reCAPTCHA no ha cargado correctamente. Por favor, recarga la página.');
+            showFormError('reCAPTCHA no ha cargado correctamente. Por favor, recarga la página.');
             isFormValid = false;
           } else {
-            // Get the response
             const recaptchaResponse = grecaptcha.getResponse();
-            console.log('reCAPTCHA response length:', recaptchaResponse?.length);
 
             if (!recaptchaResponse || recaptchaResponse.length === 0) {
-              alert('Por favor, complete el captcha para continuar');
+              showFormError('Por favor, completa el captcha para continuar.');
               isFormValid = false;
             }
           }
         } catch (error) {
           console.error('Error checking reCAPTCHA:', error);
-          alert('Error al verificar reCAPTCHA. Por favor, recarga la página e intenta de nuevo.');
+          showFormError(
+            'Error al verificar reCAPTCHA. Por favor, recarga la página e intenta de nuevo.'
+          );
           isFormValid = false;
         }
       }
@@ -507,97 +488,73 @@ const contactForm = {
       }
     });
 
-    // Pageclip integration with better UX
-    if (typeof Pageclip !== 'undefined') {
-      Pageclip.form(form, {
-        onSubmit: function () {
-          // Show loading state on the button
-          submitButton.classList.add('is-loading');
-          submitButtonContent.classList.add('hidden');
-          submitButtonLoading.classList.remove('hidden');
-          submitButtonLoading.classList.add('flex');
-
-          // Disable button and inputs during submission to prevent multiple submissions
-          submitButton.disabled = true;
-          form.querySelectorAll('input, textarea').forEach((input) => {
-            input.disabled = true;
-          });
-
-          return validateForm();
-        },
-        onResponse: function (error) {
-          // Ocultar mensajes de Pageclip predeterminados inmediatamente
-          hideDefaultPageclipMessage();
-
-          if (!error) {
-            // Evitar redireccionamiento y mostrar nuestro mensaje personalizado
-            if (currentSubmitEvent && currentSubmitEvent.preventDefault) {
-              currentSubmitEvent.preventDefault();
-            }
-
-            // Hide form and show success message with smooth animation
-            formContainer.style.height = formContainer.offsetHeight + 'px';
-            formContainer.style.opacity = '1';
-
-            setTimeout(() => {
-              formContainer.style.height = '0';
-              formContainer.style.opacity = '0';
-              formContainer.style.overflow = 'hidden';
-              formContainer.style.margin = '0';
-              formContainer.style.padding = '0';
-
-              // Show success message
-              successMessage.classList.remove('hidden');
-              responseContainer.style.height = 'auto';
-              responseContainer.style.opacity = '1';
-
-              // Asegurarnos de que el mensaje predeterminado siga oculto
-              hideDefaultPageclipMessage();
-            }, 100);
-
-            // Track form submission (if analytics exists)
-            if (typeof gtag === 'function') {
-              gtag('event', 'form_submission', {
-                event_category: 'Contact',
-                event_label: 'Contact Form',
-              });
-            }
-          } else {
-            // Reset button and form state on error
-            submitButton.classList.remove('is-loading');
-            submitButtonLoading.classList.add('hidden');
-            submitButtonLoading.classList.remove('flex');
-            submitButtonContent.classList.remove('hidden');
-            submitButton.disabled = false;
-            form.querySelectorAll('input, textarea').forEach((input) => {
-              input.disabled = false;
-            });
-
-            // Show error alert
-            alert('Ocurrió un error al enviar el formulario. Por favor, inténtalo de nuevo.');
-          }
-        },
+    function setSubmitting(isSubmitting) {
+      submitButton.classList.toggle('is-loading', isSubmitting);
+      submitButtonContent.classList.toggle('hidden', isSubmitting);
+      submitButtonLoading.classList.toggle('hidden', !isSubmitting);
+      submitButtonLoading.classList.toggle('flex', isSubmitting);
+      submitButton.disabled = isSubmitting;
+      form.querySelectorAll('input, textarea').forEach((input) => {
+        input.disabled = isSubmitting;
       });
-
-      // Observar cambios en el DOM para eliminar el mensaje de agradecimiento de Pageclip
-      const observer = new MutationObserver(hideDefaultPageclipMessage);
-      observer.observe(document.body, { childList: true, subtree: true });
     }
 
-    // Only perform reCAPTCHA checks if not in development mode
-    if (
-      !contactForm.recaptcha.isDevelopment &&
-      contactForm.recaptcha.enabled &&
-      window.grecaptcha
-    ) {
-      try {
-        window.grecaptcha.ready(function () {
-          console.log('reCAPTCHA is ready');
+    function showSuccess() {
+      // Hide form and show success message with smooth animation
+      formContainer.style.height = formContainer.offsetHeight + 'px';
+      formContainer.style.opacity = '1';
+
+      setTimeout(() => {
+        formContainer.style.height = '0';
+        formContainer.style.opacity = '0';
+        formContainer.style.overflow = 'hidden';
+        formContainer.style.margin = '0';
+        formContainer.style.padding = '0';
+
+        successMessage.classList.remove('hidden');
+        responseContainer.style.height = 'auto';
+        responseContainer.style.opacity = '1';
+      }, 100);
+
+      // Track form submission (if analytics exists)
+      if (typeof gtag === 'function') {
+        gtag('event', 'form_submission', {
+          event_category: 'Contact',
+          event_label: 'Contact Form',
         });
-      } catch (error) {
-        console.error('Error initializing reCAPTCHA:', error);
       }
     }
+
+    // Submit via fetch + FormData (the same payload shape Pageclip's action
+    // URL accepts from a plain HTML form POST) so we control the response
+    // handling directly, instead of depending on Pageclip's optional JS
+    // enhancement library (which isn't loaded on this site).
+    form.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      hideFormError();
+
+      if (!contactForm.isConfigured || !validateForm()) return;
+
+      setSubmitting(true);
+
+      try {
+        const response = await fetch(form.action, {
+          method: 'POST',
+          headers: { Accept: 'application/json' },
+          body: new FormData(form),
+        });
+
+        if (!response.ok) {
+          throw new Error(`Request failed with status ${response.status}`);
+        }
+
+        showSuccess();
+      } catch (error) {
+        console.error('Contact form submission failed:', error);
+        setSubmitting(false);
+        showFormError('Ocurrió un error al enviar el formulario. Por favor, inténtalo de nuevo.');
+      }
+    });
 
     // Asegurarnos de que el botón de envío se muestre correctamente al cargar la página
     if (submitButtonContent) {

--- a/src/utils/newsletterForm.ts
+++ b/src/utils/newsletterForm.ts
@@ -1,0 +1,58 @@
+/**
+ * Shared newsletter signup handler for the footer and CTA banner forms.
+ * Submits via fetch + FormData (the same payload shape Pageclip's action
+ * URL accepts from a plain HTML form POST) with inline, accessible
+ * feedback instead of alert().
+ */
+export interface NewsletterFormOptions {
+  formId: string;
+  messageId: string;
+}
+
+export function initNewsletterForm({ formId, messageId }: NewsletterFormOptions): void {
+  const form = document.getElementById(formId) as HTMLFormElement | null;
+  const message = document.getElementById(messageId);
+  if (!form) return;
+
+  const emailInput = form.querySelector('input[type="email"]') as HTMLInputElement | null;
+  const submitButton = form.querySelector('button[type="submit"]') as HTMLButtonElement | null;
+
+  function showMessage(text: string, tone: 'success' | 'error'): void {
+    if (!message) return;
+    message.textContent = text;
+    message.classList.remove('hidden', 'text-red-200', 'text-green-200');
+    message.classList.add(tone === 'success' ? 'text-green-200' : 'text-red-200');
+  }
+
+  form.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    if (!emailInput || !emailInput.value) return;
+
+    emailInput.disabled = true;
+    if (submitButton) submitButton.disabled = true;
+
+    try {
+      const response = await fetch(form.action, {
+        method: 'POST',
+        headers: { Accept: 'application/json' },
+        body: new FormData(form),
+      });
+
+      if (!response.ok) {
+        throw new Error(`Request failed with status ${response.status}`);
+      }
+
+      showMessage('¡Gracias por suscribirte! Pronto recibirás nuestras novedades.', 'success');
+      form.reset();
+    } catch (error) {
+      console.error('Newsletter signup failed:', error);
+      showMessage(
+        'Hubo un error al procesar tu suscripción. Por favor, inténtalo de nuevo.',
+        'error'
+      );
+    } finally {
+      emailInput.disabled = false;
+      if (submitButton) submitButton.disabled = false;
+    }
+  });
+}

--- a/tests/e2e/forms.spec.ts
+++ b/tests/e2e/forms.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Without PUBLIC_PAGECLIP_KEY configured (the default in this environment),
+ * the contact form and both newsletter forms must be disabled and must
+ * never attempt a request to Pageclip — see issue #61.
+ */
+test.describe('Forms without Pageclip configured', () => {
+  test('footer newsletter form is disabled and makes no request', async ({ page }) => {
+    const pageclipRequests: string[] = [];
+    page.on('request', (req) => {
+      if (req.url().includes('pageclip.co')) pageclipRequests.push(req.url());
+    });
+
+    await page.goto('/');
+
+    const input = page.locator('#footer-newsletter-form input[type="email"]');
+    const button = page.locator('#footer-newsletter-form button[type="submit"]');
+    await expect(input).toBeDisabled();
+    await expect(button).toBeDisabled();
+    expect(pageclipRequests).toEqual([]);
+  });
+
+  test('contact form shows a disabled-configuration notice and disables submission', async ({
+    page,
+  }) => {
+    const pageclipRequests: string[] = [];
+    page.on('request', (req) => {
+      if (req.url().includes('pageclip.co')) pageclipRequests.push(req.url());
+    });
+
+    await page.goto('/contacto');
+
+    await expect(page.getByText('Formulario Desactivado')).toBeVisible();
+    await expect(page.locator('#submit-button')).toBeDisabled();
+    expect(pageclipRequests).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Resolves #61 (scoped to the concrete bugs below; see "Deferred").

### Real bug found

The Pageclip JS client library (`pageclip.js`) is never loaded anywhere on the site — confirmed via `grep -rln pageclip src public`. `Form.astro`'s submit logic is entirely gated behind `if (typeof Pageclip !== 'undefined') { Pageclip.form(form, {...}) }`, which never runs. In practice, submitting the contact form today does a raw full-page-navigating POST, bypassing all the validation/loading-state/success-message UI that was written for it. Separately, both newsletter forms (`Footer.astro`, `CTA-Banner.astro`) hand-built a **JSON** body for an endpoint that expects a standard form POST, and neither guarded against an empty `PUBLIC_PAGECLIP_KEY` (would build a broken `.../{empty}/newsletter` URL and still let the user submit).

### Changes

- Contact form: replaced the `Pageclip.form()` dependency with a direct `fetch(form.action, { body: new FormData(form) })` submit handler — same payload shape a plain HTML form POST sends (Pageclip's actual documented integration path), just without navigating away, so the existing loading-state/inline-validation/success-message UI actually runs now.
- Extracted newsletter submit handling into one shared `initNewsletterForm()` (`src/utils/newsletterForm.ts`), used by both `Footer.astro` and `CTA-Banner.astro` instead of two near-identical copies of hand-rolled JSON-fetch code.
- Both newsletter forms now disable their input/button and build no request URL when `PUBLIC_PAGECLIP_KEY` is empty — matching the guard the contact form already had.
- Replaced every `alert()` across all three forms with inline, `aria-live` feedback.
- Removed diagnostic `console.log` calls from the contact form (kept `console.error` for real failures) — lint warnings dropped from 130 to 123.
- Dropped non-`PUBLIC_`-prefixed env var fallbacks (`PAGECLIP_KEY`, `ENABLE_RECAPTCHA`, `RECAPTCHA_SITE_KEY`, `IS_DEVELOPMENT`) — static site, one canonical `PUBLIC_` name per setting instead of a confusing fallback chain.
- New E2E test (`tests/e2e/forms.spec.ts`): with no Pageclip key configured (this repo's actual current state), both the footer newsletter form and the contact form render fully disabled and issue **zero** requests to `pageclip.co`.

### How I verified this without a real Pageclip account

Ran the dev server and drove it with Playwright against mocked responses (`page.route(...)`):
- Success path: mocked 200 → inline success message shows, form resets, no `alert()`.
- Error path: mocked 500 → inline error banner shows (`page.on('dialog', ...)` confirmed zero `alert()` calls).
- Unconfigured (this repo's real current state, no `PUBLIC_PAGECLIP_KEY`): footer newsletter and contact form both render disabled, zero `pageclip.co` requests — now also a persisted E2E test.

## Deferred (out of scope here)

- reCAPTCHA is unchanged (still loads dynamically when `PUBLIC_ENABLE_RECAPTCHA`/`PUBLIC_RECAPTCHA_SITE_KEY` are set) — untouched since it's a separate, already-working concern.
- No live round-trip against a real Pageclip account/key — don't have one. If the actual field-name contract Pageclip expects differs from this form's `name="..."` attributes, that'd need to surface against a real key.
- Broader privacy-policy content updates mentioned in #61 — that's a copy/legal decision, not something I should write.

## Test plan

- [x] `bun run format:check` / `lint` / `check` / `build` — all clean
- [x] `bun run test:unit` — 65/65 pass (unaffected)
- [x] `bun run test:e2e` — 11/11 pass, run 3x to rule out flakiness (all stable; one transient unrelated flake on an unmodified test during the first run turned out to be sandbox resource contention, not a regression — reproduced the same flow manually via a standalone Playwright script and it passed cleanly)
- [x] Manually verified success/error/unconfigured states for all three forms via mocked network, confirmed zero `alert()` calls and zero invalid Pageclip requests when unconfigured