### PR TITLE
fix(security): add browser security headers and harden third-party scripts

### DIFF
--- a/public/admin/preview.css
+++ b/public/admin/preview.css
@@ -1,4 +1,7 @@
-@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&family=Lora:ital,wght@0,400;0,700;1,400&display=swap');
+/* Falls back to the browser's default sans-serif/serif stack instead of
+   importing from Google Fonts — this project self-hosts fonts via
+   @fontsource everywhere else, and this stylesheet only affects the
+   editor-only Decap CMS live-preview pane, not the public site. */
 
 body {
   font-family: 'Poppins', sans-serif;

--- a/src/components/MediaCarousel.astro
+++ b/src/components/MediaCarousel.astro
@@ -87,6 +87,7 @@ const thumbnails = validMediaItems.map((item, index) => {
                 playlabel={`Play: ${item.title || `${title} - Video`}`}
                 style={`background-image: url('https://img.youtube.com/vi/${extractYoutubeId(item.url)}/maxresdefault.jpg');`}
                 params="autoplay=1&rel=0"
+                nocookie
               />
             </div>
           )}

--- a/vercel.json
+++ b/vercel.json
@@ -7,5 +7,37 @@
       "main": false,
       "develop": false
     }
-  }
+  },
+  "headers": [
+    {
+      "source": "/admin/(.*)",
+      "headers": [
+        {
+          "key": "Content-Security-Policy",
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://unpkg.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://api.github.com https://avatars.githubusercontent.com https://api.netlify.com https://unpkg.com; frame-src 'none'; frame-ancestors 'none'; object-src 'none'; base-uri 'self'; form-action 'self'"
+        },
+        { "key": "X-Content-Type-Options", "value": "nosniff" },
+        { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
+        {
+          "key": "Permissions-Policy",
+          "value": "camera=(), microphone=(), geolocation=(), payment=(), usb=(), interest-cohort=()"
+        }
+      ]
+    },
+    {
+      "source": "/((?!admin/).*)",
+      "headers": [
+        {
+          "key": "Content-Security-Policy",
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://www.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://res.cloudinary.com https://img.youtube.com https://i.ytimg.com https://s.ytimg.com https://i.pravatar.cc https://placehold.co; font-src 'self' data:; connect-src 'self' https://send.pageclip.co; frame-src https://www.youtube-nocookie.com https://www.google.com; frame-ancestors 'none'; object-src 'none'; base-uri 'self'; form-action 'self' https://send.pageclip.co"
+        },
+        { "key": "X-Content-Type-Options", "value": "nosniff" },
+        { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
+        {
+          "key": "Permissions-Policy",
+          "value": "camera=(), microphone=(), geolocation=(), payment=(), usb=(), interest-cohort=()"
+        }
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

Resolves #60 (scoped to what's below; see "Deferred").

Adds a Content-Security-Policy plus `X-Content-Type-Options`, `Referrer-Policy`, and `Permissions-Policy` via `vercel.json`, split into two policies:
- **Public site** (`/((?!admin/).*)`) — strict, allowlists only origins the site actually loads from.
- **`/admin/(.*)`** (Decap CMS) — separately scoped, more permissive where Decap genuinely needs it.

I deliberately made the two `source` patterns **mutually exclusive** (negative-lookahead regex vs. `/admin/(.*)`) instead of relying on how Vercel merges headers when multiple rules match the same path — I couldn't verify that merge behavior (override vs. intersect vs. array-order-dependent) without a live deployment, so I removed the ambiguity instead of guessing.

### How the allowlist was built

Not guesswork — inventoried every external origin the site actually loads from, including runtime behavior of `@justinribeiro/lite-youtube` inside `node_modules` (grepping `src/` alone misses that a library preconnects to origins that never appear as a literal string in this repo). Full breakdown:

**Public site:**
- `script-src`: `'self' 'unsafe-inline'` (the codebase has several `is:inline` scripts — `Layout.astro`, `Form.astro`, `QuestionCard.astro`, the three `*Details.astro` files — removing `unsafe-inline` would mean converting all of them to external files or per-page hashes, out of scope here and explicitly called "when feasible" in the issue, not mandatory) + `www.google.com`/`www.gstatic.com` for reCAPTCHA's `api.js`.
- `style-src`: `'self' 'unsafe-inline'` — required because `astro.config.mjs` sets `inlineStylesheets: 'always'`, so every page's CSS ships as inline `<style>`. Changing that build setting is a performance/build decision (issue #62's territory), not touched here.
- `img-src`: `res.cloudinary.com` (all product images), `img.youtube.com` + `i.ytimg.com` + `s.ytimg.com` (video thumbnails — the latter two are only reachable by grepping `@justinribeiro/lite-youtube`'s own source, not this repo), `i.pravatar.cc` + `placehold.co` (testimonial avatars / broken-image fallback).
- `connect-src`: `send.pageclip.co` (contact/newsletter form submissions, from #61).
- `frame-src`: `www.youtube-nocookie.com` (see below) + `www.google.com` (reCAPTCHA's challenge iframe).
- `frame-ancestors 'none'`, `object-src 'none'`, `base-uri 'self'`.

**`/admin` (Decap CMS):**
- `script-src`: adds `unpkg.com` (the pinned+SRI'd Decap script from #52) and `'unsafe-eval'` — see "real bug caught" below.
- `img-src`: `https:` wildcard (Decap's media browser can point at arbitrary uploaded/linked image hosts; this is an authenticated single-user tool, not the public attack surface, so I didn't try to enumerate every possible host).
- `connect-src`: `api.github.com` + `avatars.githubusercontent.com` (GitHub backend) + `api.netlify.com`. That last one is **unconfirmed** — `config.yml` doesn't set a custom OAuth `base_url`, and Decap's `github` backend defaults to Netlify's OAuth proxy in that case. This project deploys to Vercel, not Netlify, so **please verify in a real browser whether `/admin` login actually works** — if it doesn't, that's a separate, pre-existing bug unrelated to this PR (the CSP change doesn't newly break anything here; I just noticed it while inventorying origins).

### Also fixed while inventorying third-party surface

- Added `nocookie` to the `<lite-youtube>` embed in `MediaCarousel.astro`. Without it, the library preconnects to `google.com`/`doubleclick.net` (ad-related) on every video hover — `nocookie` switches to `youtube-nocookie.com` and shrinks the CSP surface needed.
- Removed a `@import url(fonts.googleapis.com/...)` from `public/admin/preview.css` (Decap's live-preview stylesheet) — it violated this project's own documented convention (AGENTS.md: "No usar Google Fonts via `<link>`... self-hostear con `@fontsource/*`") and would've forced two more origins into the admin CSP for a preview pane that doesn't need pixel-perfect fonts. Falls back to the system sans-serif/serif stack now.

### Real bug this caught during testing

Built the site, served `dist/` through a throwaway local server applying the exact header rules from `vercel.json` by path, and drove it with Playwright across home/catalog/book/pack/exam-detail (with video)/checkout/contacto/testimonios **and /admin**. Zero CSP console violations on the public pages on the first try. On `/admin`, Decap's schema validator (likely `ajv`, compiles JSON-schema validators via `new Function()`) threw a hard CSP `unsafe-eval` error that broke CMS initialization entirely — added `'unsafe-eval'` scoped only to `/admin`'s script-src to fix it, confirmed the CMS renders its login screen cleanly afterward.

## Deferred (out of scope here)

- **No HSTS.** `siteConfig.url` (`fluentreads.sandovaldavid.com`) doesn't currently resolve via DNS (checked) — issue #60 explicitly says HSTS should wait until domain + HTTPS are validated live. Add it once there's a real deployed domain.
- **Removing `unsafe-inline`/`unsafe-eval` entirely** would need converting several inline scripts to external files (public site) and possibly vendoring/patching Decap's schema validator (admin) — both bigger, separate efforts. Documented as accepted risk per the issue's own acceptance criteria.
- **Confirming `/admin` OAuth actually works** — needs a real browser + real GitHub OAuth app, which I can't drive headlessly.
- Real production verification against actual Vercel headers — I don't have deploy credentials (same gap noted in the #63 PR: `VERCEL_ORG_ID`/`VERCEL_PROJECT_ID` secrets are missing).

## Test plan

- [x] `bun run format:check` / `lint` / `check` / `build` — all clean
- [x] `bun run test:unit` — 65/65 pass (unaffected)
- [x] `bun run test:e2e` — 11/11 pass, run twice for stability (one unrelated flake on an unmodified test in an earlier run was sandbox resource contention, reproduced as passing on rerun)
- [x] `node -e "JSON.parse(...)"` — `vercel.json` is valid JSON
- [x] Manually verified via a local server + Playwright that the two header rules route correctly by path (`/`, `/catalogo` → public CSP; `/admin/` → admin CSP) and produce **zero CSP console violations** across every real page type, including the video-embed and admin CMS pages
