### PR TITLE
fix(checkout): verify catalog prices and make WhatsApp order totals trustworthy

### DIFF
--- a/src/components/Card.astro
+++ b/src/components/Card.astro
@@ -192,7 +192,7 @@ const isFeaturedOrBestseller =
 </div>
 
 <script>
-  import { CartManager } from '../utils/cartManager';
+  import { CartManager, type ProductType } from '../utils/cartManager';
 
   // Mobile click to expand functionality. The card itself is not a focusable
   // control (the real "Ver Detalles" link and "Comprar" button already cover
@@ -216,20 +216,12 @@ const isFeaturedOrBestseller =
         e.stopPropagation();
 
         const id = btn.getAttribute('data-id');
-        const title = btn.getAttribute('data-title');
-        const priceStr = btn.getAttribute('data-price');
-        const image = btn.getAttribute('data-image');
         const type = btn.getAttribute('data-type');
 
-        if (id && title && priceStr && image && type) {
-          CartManager.addItem({
-            id,
-            title,
-            price: parseFloat(priceStr),
-            image,
-            type: type as any,
-          });
-
+        if (id && type) {
+          // Only identity is persisted — price/title are resolved from the
+          // canonical catalog at checkout, never trusted from this button.
+          CartManager.addItem(id, type as ProductType);
           window.location.href = '/checkout';
         }
       });

--- a/src/components/PromoCard.astro
+++ b/src/components/PromoCard.astro
@@ -24,9 +24,12 @@ interface Props {
 
 const { Offer, index, size = 'large' } = Astro.props;
 
-// Extract ID and type from the link if they aren't provided directly
+// Offers are their own catalog entity (src/data/offers.json), resolved at
+// checkout the same way books/packs/exams are — never a guess based on the
+// offer id's naming, and never a book/pack id (offers aren't 1:1 with a
+// single product).
 const offerId = Offer.id || (Offer.link ? Offer.link.replace('/checkout/', '') : '');
-const offerType = Offer.type || (offerId.startsWith('pack-') ? 'pack' : 'book');
+const offerType = 'offer';
 
 // Default details link if not provided
 const detailsLink =
@@ -218,7 +221,7 @@ const priceSize = isSmallLayout ? 'text-sm' : isMediumLayout ? 'text-base' : 'te
 </div>
 
 <script>
-  import { CartManager } from '../utils/cartManager';
+  import { CartManager, type ProductType } from '../utils/cartManager';
 
   document.addEventListener('DOMContentLoaded', () => {
     document.querySelectorAll('.promo-add-to-cart').forEach((btn) => {
@@ -227,20 +230,12 @@ const priceSize = isSmallLayout ? 'text-sm' : isMediumLayout ? 'text-base' : 'te
         e.stopPropagation();
 
         const id = btn.getAttribute('data-id');
-        const title = btn.getAttribute('data-title');
-        const priceStr = btn.getAttribute('data-price');
-        const image = btn.getAttribute('data-image');
         const type = btn.getAttribute('data-type');
 
-        if (id && title && priceStr && image && type) {
-          CartManager.addItem({
-            id,
-            title,
-            price: parseFloat(priceStr),
-            image,
-            type: type as any,
-          });
-
+        if (id && type) {
+          // Only identity is persisted — price/title are resolved from the
+          // canonical catalog at checkout, never trusted from this button.
+          CartManager.addItem(id, type as ProductType);
           window.location.href = '/checkout';
         }
       });

--- a/src/components/details/BookDetails.astro
+++ b/src/components/details/BookDetails.astro
@@ -510,7 +510,7 @@ const jsonLd = {
 </div>
 
 <script>
-  import { CartManager } from '../../utils/cartManager';
+  import { CartManager, type ProductType } from '../../utils/cartManager';
 
   document.addEventListener('DOMContentLoaded', () => {
     // Add event listeners to "Add to Cart" buttons
@@ -519,24 +519,15 @@ const jsonLd = {
       btn.addEventListener('click', () => {
         const productId = btn.getAttribute('data-id');
         const productTitle = btn.getAttribute('data-title');
-        const productPriceStr = btn.getAttribute('data-price');
-        const productImage = btn.getAttribute('data-image');
         const productType = btn.getAttribute('data-type');
 
-        if (productId && productTitle && productPriceStr && productImage && productType) {
-          const productPrice = parseFloat(productPriceStr);
-
-          // Add item to cart using CartManager
-          CartManager.addItem({
-            id: productId,
-            title: productTitle,
-            price: productPrice,
-            image: productImage,
-            type: productType as 'book' | 'exam' | 'pack',
-          });
+        if (productId && productType) {
+          // Only identity is persisted — price/title are resolved from the
+          // canonical catalog at checkout, never trusted from this button.
+          CartManager.addItem(productId, productType as ProductType);
 
           // Show success message
-          CartManager.showNotification(`"${productTitle}" agregado al carrito`);
+          CartManager.showNotification(`"${productTitle || 'Producto'}" agregado al carrito`);
 
           // Dispatch event to notify other components about cart update
           window.dispatchEvent(new CustomEvent('cartUpdated'));

--- a/src/components/details/ExamDetails.astro
+++ b/src/components/details/ExamDetails.astro
@@ -532,7 +532,7 @@ const jsonLd = {
 </div>
 
 <script>
-  import { CartManager } from '../../utils/cartManager';
+  import { CartManager, type ProductType } from '../../utils/cartManager';
 
   document.addEventListener('DOMContentLoaded', () => {
     // Add event listeners to "Add to Cart" buttons
@@ -541,24 +541,15 @@ const jsonLd = {
       btn.addEventListener('click', () => {
         const productId = btn.getAttribute('data-id');
         const productTitle = btn.getAttribute('data-title');
-        const productPriceStr = btn.getAttribute('data-price');
-        const productImage = btn.getAttribute('data-image');
         const productType = btn.getAttribute('data-type');
 
-        if (productId && productTitle && productPriceStr && productImage && productType) {
-          const productPrice = parseFloat(productPriceStr);
-
-          // Add item to cart using CartManager
-          CartManager.addItem({
-            id: productId,
-            title: productTitle,
-            price: productPrice,
-            image: productImage,
-            type: productType as 'book' | 'exam' | 'pack',
-          });
+        if (productId && productType) {
+          // Only identity is persisted — price/title are resolved from the
+          // canonical catalog at checkout, never trusted from this button.
+          CartManager.addItem(productId, productType as ProductType);
 
           // Show success message
-          CartManager.showNotification(`"${productTitle}" agregado al carrito`);
+          CartManager.showNotification(`"${productTitle || 'Producto'}" agregado al carrito`);
 
           // Dispatch event to notify other components about cart update
           window.dispatchEvent(new CustomEvent('cartUpdated'));

--- a/src/components/details/PackDetails.astro
+++ b/src/components/details/PackDetails.astro
@@ -533,7 +533,7 @@ const jsonLd = {
 </div>
 
 <script>
-  import { CartManager } from '../../utils/cartManager';
+  import { CartManager, type ProductType } from '../../utils/cartManager';
 
   document.addEventListener('DOMContentLoaded', () => {
     // Add event listeners to "Add to Cart" buttons
@@ -542,24 +542,15 @@ const jsonLd = {
       btn.addEventListener('click', () => {
         const productId = btn.getAttribute('data-id');
         const productTitle = btn.getAttribute('data-title');
-        const productPriceStr = btn.getAttribute('data-price');
-        const productImage = btn.getAttribute('data-image');
         const productType = btn.getAttribute('data-type');
 
-        if (productId && productTitle && productPriceStr && productImage && productType) {
-          const productPrice = parseFloat(productPriceStr);
-
-          // Add item to cart using CartManager
-          CartManager.addItem({
-            id: productId,
-            title: productTitle,
-            price: productPrice,
-            image: productImage,
-            type: productType as 'book' | 'exam' | 'pack',
-          });
+        if (productId && productType) {
+          // Only identity is persisted — price/title are resolved from the
+          // canonical catalog at checkout, never trusted from this button.
+          CartManager.addItem(productId, productType as ProductType);
 
           // Show success message
-          CartManager.showNotification(`"${productTitle}" agregado al carrito`);
+          CartManager.showNotification(`"${productTitle || 'Producto'}" agregado al carrito`);
 
           // Dispatch event to notify other components about cart update
           window.dispatchEvent(new CustomEvent('cartUpdated'));

--- a/src/pages/checkout.astro
+++ b/src/pages/checkout.astro
@@ -1,14 +1,61 @@
 ---
+import { getCollection } from 'astro:content';
 import Layout from '../layouts/Layout.astro';
 import Button from '../components/Button.astro';
 import WhatsAppIcon from '../components/icons/WhatsApp.astro';
-// CartIcon removed
 import SectionTitle from '../components/SectionTitle.astro';
 
 import { siteConfig } from '@config/site';
+import { buildCanonicalCatalog, type CanonicalProduct } from '@utils/catalogPricing';
 
 // WhatsApp business number
 const whatsappNumber = siteConfig.whatsapp;
+
+// Canonical, build-time catalog — the only source checkout trusts for
+// title/image/price. Embedded below as JSON for the client script to
+// resolve the (untrusted) cart contents against. See issue #54.
+const [books, packs, exams, offers] = await Promise.all([
+  getCollection('books'),
+  getCollection('packs'),
+  getCollection('exams'),
+  getCollection('offers'),
+]);
+
+const canonicalCatalog: CanonicalProduct[] = buildCanonicalCatalog([
+  ...books.map((entry) => ({
+    id: entry.data.id,
+    type: 'book' as const,
+    title: entry.data.title,
+    image: entry.data.coverImage,
+    price: entry.data.price,
+    discount: entry.data.discount,
+  })),
+  ...packs.map((entry) => ({
+    id: entry.data.id,
+    type: 'pack' as const,
+    title: entry.data.title,
+    image: entry.data.coverImage,
+    price: entry.data.price,
+    discount: entry.data.discount,
+  })),
+  ...exams.map((entry) => ({
+    id: entry.data.id,
+    type: 'exam' as const,
+    title: entry.data.title,
+    image: entry.data.coverImage,
+    price: entry.data.price,
+    discount: entry.data.discount,
+  })),
+  ...offers.map((entry) => ({
+    id: entry.data.id,
+    type: 'offer' as const,
+    title: entry.data.title,
+    image: entry.data.image,
+    // salePrice is already the final amount to charge for an offer bundle.
+    price: entry.data.salePrice,
+    discount: 0,
+  })),
+]);
 ---
 
 <Layout
@@ -16,8 +63,22 @@ const whatsappNumber = siteConfig.whatsapp;
   description="Revisa y confirma tu pedido de libros digitales en inglés con FluentReads."
 >
   <div id="checkout-data" data-whatsapp={whatsappNumber} class="hidden"></div>
+  <script
+    is:inline
+    type="application/json"
+    id="canonical-catalog"
+    set:html={JSON.stringify(canonicalCatalog)}
+  />
   <div class="mx-auto max-w-4xl px-4 py-12">
     <SectionTitle tag="h1">Tu Carrito de Compras</SectionTitle>
+
+    <div
+      id="removed-items-notice"
+      class="mb-6 hidden border-l-4 border-amber-400 bg-amber-50 p-4 text-sm text-amber-800"
+      role="status"
+      aria-live="polite"
+    >
+    </div>
 
     <div id="empty-cart-message" class="hidden py-12 text-center">
       <div class="mb-4 text-6xl">🛒</div>
@@ -69,16 +130,25 @@ const whatsappNumber = siteConfig.whatsapp;
 </Layout>
 
 <script>
-  import { CartManager, type CartItem } from '@utils/cartManager';
-  import { buildWhatsAppMessage, buildWhatsAppUrl } from '@utils/checkoutMessage';
+  import { CartManager, type ProductType } from '@utils/cartManager';
+  import { resolveCart, type CanonicalProduct } from '@utils/catalogPricing';
+  import {
+    buildWhatsAppMessage,
+    buildWhatsAppUrl,
+    generateOrderRequestId,
+  } from '@utils/checkoutMessage';
 
   document.addEventListener('DOMContentLoaded', () => {
     const checkoutDataEl = document.getElementById('checkout-data');
     const whatsappNumber = checkoutDataEl?.getAttribute('data-whatsapp') || '';
 
+    const catalogEl = document.getElementById('canonical-catalog');
+    const catalog: CanonicalProduct[] = catalogEl ? JSON.parse(catalogEl.textContent || '[]') : [];
+
     // Get DOM elements safely
     const cartContainer = document.getElementById('cart-container')!;
     const emptyCartMessage = document.getElementById('empty-cart-message')!;
+    const removedItemsNotice = document.getElementById('removed-items-notice')!;
     const cartItemsContainer = document.getElementById('cart-items')!;
     const cartTotalElement = document.getElementById('cart-total')!;
     const whatsappCheckoutBtn = document.getElementById('whatsapp-checkout-btn')!;
@@ -87,6 +157,7 @@ const whatsappNumber = siteConfig.whatsapp;
     if (
       !cartContainer ||
       !emptyCartMessage ||
+      !removedItemsNotice ||
       !cartItemsContainer ||
       !cartTotalElement ||
       !whatsappCheckoutBtn ||
@@ -96,151 +167,155 @@ const whatsappNumber = siteConfig.whatsapp;
       return;
     }
 
-    // Function to escape HTML to prevent XSS
-    function escapeHTML(str: string): string {
-      if (!str) return '';
-      return String(str).replace(
-        /[&<>'"]/g,
-        (tag) =>
-          ({
-            '&': '&amp;',
-            '<': '&lt;',
-            '>': '&gt;',
-            "'": '&#39;',
-            '"': '&quot;',
-          })[tag] || tag
-      );
-    }
+    const typeLabels: Record<string, string> = {
+      book: 'Libro',
+      exam: 'Examen',
+      pack: 'Pack',
+      offer: 'Oferta',
+    };
 
-    // Load cart data
+    // Load cart data, resolved against the canonical catalog embedded above.
     function loadCart() {
-      const cart = CartManager.getCart();
+      const rawCart = CartManager.getCart();
+      const resolved = resolveCart(rawCart, catalog);
 
-      // Show/hide appropriate elements based on cart state
-      if (cart.length === 0) {
+      // Products that no longer exist in the catalog can't be trusted or
+      // priced — drop them from storage and tell the user why.
+      if (resolved.removedIds.length > 0) {
+        for (const item of rawCart) {
+          if (resolved.removedIds.includes(item.id)) {
+            CartManager.removeItem(item.id, item.type);
+          }
+        }
+        removedItemsNotice.textContent =
+          resolved.removedIds.length === 1
+            ? 'Un producto de tu carrito ya no está disponible y fue eliminado.'
+            : `${resolved.removedIds.length} productos de tu carrito ya no están disponibles y fueron eliminados.`;
+        removedItemsNotice.classList.remove('hidden');
+      } else {
+        removedItemsNotice.classList.add('hidden');
+      }
+
+      if (resolved.lines.length === 0) {
         cartContainer.classList.add('hidden');
         emptyCartMessage.classList.remove('hidden');
-      } else {
-        cartContainer.classList.remove('hidden');
-        emptyCartMessage.classList.add('hidden');
-
-        // Clear previous items safely
-        while (cartItemsContainer.firstChild) {
-          cartItemsContainer.removeChild(cartItemsContainer.firstChild);
-        }
-
-        const total = CartManager.getCartTotal();
-
-        // Render cart items using DOM APIs to prevent XSS
-        cart.forEach((item: CartItem) => {
-          // Escape inputs
-          const cleanTitle = escapeHTML(item.title);
-          const cleanImage = escapeHTML(item.image);
-          const cleanType = escapeHTML(item.type);
-
-          // Create cart item element
-          const cartItemEl = document.createElement('div');
-          cartItemEl.className =
-            'flex flex-col sm:flex-row items-center bg-white p-4 rounded-lg shadow-sm border border-gray-200';
-
-          // Image container
-          const imgContainer = document.createElement('div');
-          imgContainer.className = 'flex-shrink-0 w-20 h-20 mb-3 sm:mb-0 sm:mr-4';
-          const img = document.createElement('img');
-          img.src = cleanImage;
-          img.alt = cleanTitle;
-          img.className = 'w-full h-full object-cover rounded';
-          imgContainer.appendChild(img);
-          cartItemEl.appendChild(imgContainer);
-
-          // Content container
-          const contentDiv = document.createElement('div');
-          contentDiv.className = 'flex-grow text-center sm:text-left';
-
-          const titleHeader = document.createElement('h4');
-          titleHeader.className = 'font-bold text-gray-800';
-          titleHeader.textContent = cleanTitle;
-          contentDiv.appendChild(titleHeader);
-
-          const typeDiv = document.createElement('div');
-          typeDiv.className = 'text-sm text-gray-500 mb-1';
-          typeDiv.textContent =
-            cleanType === 'book' ? 'Libro' : cleanType === 'exam' ? 'Examen' : 'Pack';
-          contentDiv.appendChild(typeDiv);
-
-          // Controls and price container
-          const controlsPriceDiv = document.createElement('div');
-          controlsPriceDiv.className =
-            'flex flex-col sm:flex-row sm:justify-between sm:items-center mt-2';
-
-          const priceDiv = document.createElement('div');
-          priceDiv.className = 'text-primary font-bold';
-          priceDiv.textContent = `S/${item.price.toFixed(2)}`;
-          controlsPriceDiv.appendChild(priceDiv);
-
-          const controlsDiv = document.createElement('div');
-          controlsDiv.className = 'mt-2 flex items-center justify-center sm:mt-0 sm:justify-end';
-
-          // Decrease button
-          const decBtn = document.createElement('button');
-          decBtn.className =
-            'quantity-btn decrease inline-flex size-11 items-center justify-center rounded-l bg-gray-100 font-medium text-gray-700 hover:bg-gray-200';
-          decBtn.setAttribute('data-id', item.id);
-          decBtn.setAttribute('aria-label', `Disminuir cantidad de ${cleanTitle}`);
-          decBtn.textContent = '-';
-          controlsDiv.appendChild(decBtn);
-
-          // Quantity display
-          const qtySpan = document.createElement('span');
-          qtySpan.className =
-            'quantity-display inline-flex min-h-11 min-w-11 items-center justify-center bg-gray-100 px-2';
-          qtySpan.textContent = String(item.quantity);
-          controlsDiv.appendChild(qtySpan);
-
-          // Increase button
-          const incBtn = document.createElement('button');
-          incBtn.className =
-            'quantity-btn increase inline-flex size-11 items-center justify-center rounded-r bg-gray-100 font-medium text-gray-700 hover:bg-gray-200';
-          incBtn.setAttribute('data-id', item.id);
-          incBtn.setAttribute('aria-label', `Aumentar cantidad de ${cleanTitle}`);
-          incBtn.textContent = '+';
-          controlsDiv.appendChild(incBtn);
-
-          // Remove button
-          const removeBtn = document.createElement('button');
-          removeBtn.className =
-            'remove-item ml-2 inline-flex size-11 items-center justify-center rounded-full text-red-600 hover:bg-red-50 hover:text-red-800';
-          removeBtn.setAttribute('data-id', item.id);
-          removeBtn.setAttribute('aria-label', `Eliminar ${cleanTitle} del carrito`);
-
-          // SVG for remove button
-          const removeSvg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
-          removeSvg.setAttribute('class', 'h-5 w-5');
-          removeSvg.setAttribute('viewBox', '0 0 20 20');
-          removeSvg.setAttribute('fill', 'currentColor');
-          removeSvg.setAttribute('aria-hidden', 'true');
-          const svgPath = document.createElementNS('http://www.w3.org/2000/svg', 'path');
-          svgPath.setAttribute('fill-rule', 'evenodd');
-          svgPath.setAttribute(
-            'd',
-            'M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z'
-          );
-          svgPath.setAttribute('clip-rule', 'evenodd');
-          removeSvg.appendChild(svgPath);
-          removeBtn.appendChild(removeSvg);
-
-          controlsDiv.appendChild(removeBtn);
-          controlsPriceDiv.appendChild(controlsDiv);
-          contentDiv.appendChild(controlsPriceDiv);
-          cartItemEl.appendChild(contentDiv);
-
-          // Add cart item to container
-          cartItemsContainer.appendChild(cartItemEl);
-        });
-
-        // Update total price display
-        cartTotalElement.textContent = `S/${total.toFixed(2)}`;
+        return;
       }
+
+      cartContainer.classList.remove('hidden');
+      emptyCartMessage.classList.add('hidden');
+
+      // Clear previous items safely
+      while (cartItemsContainer.firstChild) {
+        cartItemsContainer.removeChild(cartItemsContainer.firstChild);
+      }
+
+      // Render cart items using DOM APIs to prevent XSS
+      resolved.lines.forEach((line) => {
+        // Create cart item element
+        const cartItemEl = document.createElement('div');
+        cartItemEl.className =
+          'flex flex-col sm:flex-row items-center bg-white p-4 rounded-lg shadow-sm border border-gray-200';
+
+        // Image container
+        const imgContainer = document.createElement('div');
+        imgContainer.className = 'flex-shrink-0 w-20 h-20 mb-3 sm:mb-0 sm:mr-4';
+        const img = document.createElement('img');
+        img.src = line.image;
+        img.alt = line.title;
+        img.className = 'w-full h-full object-cover rounded';
+        imgContainer.appendChild(img);
+        cartItemEl.appendChild(imgContainer);
+
+        // Content container
+        const contentDiv = document.createElement('div');
+        contentDiv.className = 'flex-grow text-center sm:text-left';
+
+        const titleHeader = document.createElement('h4');
+        titleHeader.className = 'font-bold text-gray-800';
+        titleHeader.textContent = line.title;
+        contentDiv.appendChild(titleHeader);
+
+        const typeDiv = document.createElement('div');
+        typeDiv.className = 'text-sm text-gray-500 mb-1';
+        typeDiv.textContent = typeLabels[line.type] || line.type;
+        contentDiv.appendChild(typeDiv);
+
+        // Controls and price container
+        const controlsPriceDiv = document.createElement('div');
+        controlsPriceDiv.className =
+          'flex flex-col sm:flex-row sm:justify-between sm:items-center mt-2';
+
+        const priceDiv = document.createElement('div');
+        priceDiv.className = 'text-primary font-bold';
+        priceDiv.textContent = `S/${line.lineTotal.toFixed(2)}`;
+        controlsPriceDiv.appendChild(priceDiv);
+
+        const controlsDiv = document.createElement('div');
+        controlsDiv.className = 'mt-2 flex items-center justify-center sm:mt-0 sm:justify-end';
+
+        // Decrease button
+        const decBtn = document.createElement('button');
+        decBtn.className =
+          'quantity-btn decrease inline-flex size-11 items-center justify-center rounded-l bg-gray-100 font-medium text-gray-700 hover:bg-gray-200';
+        decBtn.setAttribute('data-id', line.id);
+        decBtn.setAttribute('data-type', line.type);
+        decBtn.setAttribute('aria-label', `Disminuir cantidad de ${line.title}`);
+        decBtn.textContent = '-';
+        controlsDiv.appendChild(decBtn);
+
+        // Quantity display
+        const qtySpan = document.createElement('span');
+        qtySpan.className =
+          'quantity-display inline-flex min-h-11 min-w-11 items-center justify-center bg-gray-100 px-2';
+        qtySpan.textContent = String(line.quantity);
+        controlsDiv.appendChild(qtySpan);
+
+        // Increase button
+        const incBtn = document.createElement('button');
+        incBtn.className =
+          'quantity-btn increase inline-flex size-11 items-center justify-center rounded-r bg-gray-100 font-medium text-gray-700 hover:bg-gray-200';
+        incBtn.setAttribute('data-id', line.id);
+        incBtn.setAttribute('data-type', line.type);
+        incBtn.setAttribute('aria-label', `Aumentar cantidad de ${line.title}`);
+        incBtn.textContent = '+';
+        controlsDiv.appendChild(incBtn);
+
+        // Remove button
+        const removeBtn = document.createElement('button');
+        removeBtn.className =
+          'remove-item ml-2 inline-flex size-11 items-center justify-center rounded-full text-red-600 hover:bg-red-50 hover:text-red-800';
+        removeBtn.setAttribute('data-id', line.id);
+        removeBtn.setAttribute('data-type', line.type);
+        removeBtn.setAttribute('aria-label', `Eliminar ${line.title} del carrito`);
+
+        // SVG for remove button
+        const removeSvg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+        removeSvg.setAttribute('class', 'h-5 w-5');
+        removeSvg.setAttribute('viewBox', '0 0 20 20');
+        removeSvg.setAttribute('fill', 'currentColor');
+        removeSvg.setAttribute('aria-hidden', 'true');
+        const svgPath = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+        svgPath.setAttribute('fill-rule', 'evenodd');
+        svgPath.setAttribute(
+          'd',
+          'M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z'
+        );
+        svgPath.setAttribute('clip-rule', 'evenodd');
+        removeSvg.appendChild(svgPath);
+        removeBtn.appendChild(removeSvg);
+
+        controlsDiv.appendChild(removeBtn);
+        controlsPriceDiv.appendChild(controlsDiv);
+        contentDiv.appendChild(controlsPriceDiv);
+        cartItemEl.appendChild(contentDiv);
+
+        // Add cart item to container
+        cartItemsContainer.appendChild(cartItemEl);
+      });
+
+      // Update total price display
+      cartTotalElement.textContent = `S/${resolved.total.toFixed(2)}`;
     }
 
     // Handle quantity changes and item removal
@@ -252,15 +327,20 @@ const whatsappNumber = siteConfig.whatsapp;
           ? target
           : (target.closest('.quantity-btn') as HTMLElement);
         const itemId = btn.getAttribute('data-id') || '';
-        if (!itemId) return;
+        const itemType = btn.getAttribute('data-type') as ProductType | null;
+        if (!itemId || !itemType) return;
         const isIncrease = btn.classList.contains('increase');
 
         const cart = CartManager.getCart();
-        const item = cart.find((i) => i.id === itemId);
+        const item = cart.find((i) => i.id === itemId && i.type === itemType);
 
         if (item) {
           const newQty = isIncrease ? item.quantity + 1 : item.quantity - 1;
-          CartManager.updateQuantity(itemId, newQty);
+          if (newQty < 1) {
+            CartManager.removeItem(itemId, itemType);
+          } else {
+            CartManager.updateQuantity(itemId, itemType, newQty);
+          }
         }
       }
 
@@ -269,9 +349,10 @@ const whatsappNumber = siteConfig.whatsapp;
           ? target
           : (target.closest('.remove-item') as HTMLElement);
         const itemId = btn.getAttribute('data-id') || '';
-        if (!itemId) return;
+        const itemType = btn.getAttribute('data-type') as ProductType | null;
+        if (!itemId || !itemType) return;
 
-        CartManager.removeItem(itemId);
+        CartManager.removeItem(itemId, itemType);
       }
     });
 
@@ -284,15 +365,13 @@ const whatsappNumber = siteConfig.whatsapp;
 
     // WhatsApp checkout button
     whatsappCheckoutBtn.addEventListener('click', () => {
-      const cart = CartManager.getCart();
+      const rawCart = CartManager.getCart();
+      const resolved = resolveCart(rawCart, catalog);
 
-      if (cart.length === 0) return;
+      if (resolved.lines.length === 0) return;
 
-      // Calculate total
-      const total = CartManager.getCartTotal();
-
-      // Prepare WhatsApp message
-      const message = buildWhatsAppMessage(cart, total);
+      const requestId = generateOrderRequestId();
+      const message = buildWhatsAppMessage(resolved.lines, resolved.total, requestId);
 
       // Open WhatsApp with the message
       window.open(buildWhatsAppUrl(whatsappNumber, message), '_blank');

--- a/src/utils/cartManager.ts
+++ b/src/utils/cartManager.ts
@@ -1,19 +1,42 @@
 /**
  * Shopping Cart Manager
  * Handles all shopping cart operations: add, remove, update items and localStorage management
+ *
+ * The cart only persists productId/productType/quantity — never price or
+ * title. Anything display-worthy (title, image, price) is resolved from the
+ * canonical build-time catalog at checkout (see src/utils/catalogPricing.ts),
+ * so tampering with localStorage can't change what a customer is charged.
  */
+
+export type ProductType = 'book' | 'exam' | 'pack' | 'offer';
 
 export interface CartItem {
   id: string;
-  title: string;
-  price: number;
-  image: string;
-  type: 'book' | 'exam' | 'pack';
+  type: ProductType;
   quantity: number;
+}
+
+const VALID_TYPES: ProductType[] = ['book', 'exam', 'pack', 'offer'];
+const MAX_QUANTITY = 99;
+
+function isValidCartItem(value: unknown): value is CartItem {
+  if (!value || typeof value !== 'object') return false;
+  const item = value as Record<string, unknown>;
+  return (
+    typeof item.id === 'string' &&
+    item.id.length > 0 &&
+    typeof item.type === 'string' &&
+    VALID_TYPES.includes(item.type as ProductType) &&
+    typeof item.quantity === 'number' &&
+    Number.isInteger(item.quantity) &&
+    item.quantity > 0 &&
+    item.quantity <= MAX_QUANTITY
+  );
 }
 
 export class CartManager {
   private static STORAGE_KEY = 'shoppingCart';
+  static readonly MAX_QUANTITY = MAX_QUANTITY;
 
   /**
    * Initialize the shopping cart in localStorage if it doesn't exist
@@ -29,39 +52,23 @@ export class CartManager {
   }
 
   /**
-   * Get all items from the cart
+   * Get all items from the cart. Entries that are malformed, corrupted, or
+   * have an out-of-range quantity are silently dropped rather than trusted.
    */
   static getCart(): CartItem[] {
     try {
       const cart = localStorage.getItem(this.STORAGE_KEY);
-      return cart ? JSON.parse(cart) : [];
+      if (!cart) return [];
+      const parsed = JSON.parse(cart);
+      if (!Array.isArray(parsed)) return [];
+      return parsed.filter(isValidCartItem);
     } catch (e) {
       console.error('Error parsing cart from localStorage:', e);
       return [];
     }
   }
 
-  /**
-   * Add an item to the cart
-   */
-  static addItem(item: Omit<CartItem, 'quantity'>): void {
-    const cart = this.getCart();
-
-    // Check if product is already in cart
-    const existingProductIndex = cart.findIndex((cartItem) => cartItem.id === item.id);
-
-    if (existingProductIndex >= 0) {
-      // Update quantity if product exists
-      cart[existingProductIndex].quantity += 1;
-    } else {
-      // Add new product to cart
-      cart.push({
-        ...item,
-        quantity: 1,
-      });
-    }
-
-    // Update cart in localStorage safely
+  private static persist(cart: CartItem[]): void {
     try {
       localStorage.setItem(this.STORAGE_KEY, JSON.stringify(cart));
       if (typeof window !== 'undefined') {
@@ -74,41 +81,45 @@ export class CartManager {
   }
 
   /**
-   * Remove an item from the cart
+   * Add a product to the cart by id/type. Only identity is persisted —
+   * price and title are resolved from the canonical catalog when needed.
    */
-  static removeItem(id: string): void {
+  static addItem(id: string, type: ProductType): void {
     const cart = this.getCart();
-    const updatedCart = cart.filter((item) => item.id !== id);
-    try {
-      localStorage.setItem(this.STORAGE_KEY, JSON.stringify(updatedCart));
-      if (typeof window !== 'undefined') {
-        window.dispatchEvent(new CustomEvent('cartUpdated'));
-      }
-    } catch (e) {
-      console.error('Failed to update cart after removal:', e);
+    const existingIndex = cart.findIndex((item) => item.id === id && item.type === type);
+
+    if (existingIndex >= 0) {
+      cart[existingIndex].quantity = Math.min(cart[existingIndex].quantity + 1, MAX_QUANTITY);
+    } else {
+      cart.push({ id, type, quantity: 1 });
     }
+
+    this.persist(cart);
   }
 
   /**
-   * Update quantity of an item in the cart
+   * Remove an item from the cart. `type` disambiguates in the (unlikely but
+   * possible) case a book/pack/exam/offer id collides across types.
    */
-  static updateQuantity(id: string, quantity: number): void {
-    if (quantity < 1) return;
+  static removeItem(id: string, type: ProductType): void {
+    const cart = this.getCart();
+    const updatedCart = cart.filter((item) => !(item.id === id && item.type === type));
+    this.persist(updatedCart);
+  }
+
+  /**
+   * Update quantity of an item in the cart. Non-integer, non-positive, or
+   * excessive quantities are ignored rather than applied.
+   */
+  static updateQuantity(id: string, type: ProductType, quantity: number): void {
+    if (!Number.isInteger(quantity) || quantity < 1 || quantity > MAX_QUANTITY) return;
 
     const cart = this.getCart();
-    const itemIndex = cart.findIndex((item) => item.id === id);
+    const itemIndex = cart.findIndex((item) => item.id === id && item.type === type);
 
     if (itemIndex !== -1) {
       cart[itemIndex].quantity = quantity;
-      try {
-        localStorage.setItem(this.STORAGE_KEY, JSON.stringify(cart));
-        if (typeof window !== 'undefined') {
-          window.dispatchEvent(new CustomEvent('cartUpdated'));
-        }
-      } catch (e) {
-        console.error('Failed to update cart quantity:', e);
-        this.showNotification('No se pudo actualizar la cantidad.', 'error');
-      }
+      this.persist(cart);
     }
   }
 
@@ -116,14 +127,7 @@ export class CartManager {
    * Clear the entire cart
    */
   static clearCart(): void {
-    try {
-      localStorage.setItem(this.STORAGE_KEY, JSON.stringify([]));
-      if (typeof window !== 'undefined') {
-        window.dispatchEvent(new CustomEvent('cartUpdated'));
-      }
-    } catch (e) {
-      console.error('Failed to clear cart:', e);
-    }
+    this.persist([]);
   }
 
   /**
@@ -134,20 +138,13 @@ export class CartManager {
   }
 
   /**
-   * Calculate the cart total price
-   */
-  static getCartTotal(): number {
-    return this.getCart().reduce((sum, item) => sum + item.price * item.quantity, 0);
-  }
-
-  /**
    * Show a notification when items are added or modified in the cart
    */
   static showNotification(message: string, type: 'success' | 'error' = 'success'): void {
     // Create notification element
     const notification = document.createElement('div');
-    notification.className = `cart-notification fixed top-20 right-4 
-      ${type === 'success' ? 'bg-green-500' : 'bg-red-500'} 
+    notification.className = `cart-notification fixed top-20 right-4
+      ${type === 'success' ? 'bg-green-500' : 'bg-red-500'}
       text-white px-6 py-3 rounded-lg shadow-lg z-50 transform transition-all duration-300 translate-x-full opacity-0`;
     notification.textContent = message;
 

--- a/src/utils/catalogPricing.ts
+++ b/src/utils/catalogPricing.ts
@@ -1,0 +1,90 @@
+import type { CartItem, ProductType } from './cartManager';
+import { calculateDiscountedPrice } from './pricing';
+
+/**
+ * A single sellable entity as known at build time — the only source
+ * checkout trusts for title/image/price. Built from Content Collections
+ * (books/packs/exams/offers), never from anything the browser can edit.
+ */
+export interface CanonicalProduct {
+  id: string;
+  type: ProductType;
+  title: string;
+  image: string;
+  /** Final unit price to charge, discount already applied. */
+  price: number;
+}
+
+export interface ResolvedCartLine {
+  id: string;
+  type: ProductType;
+  title: string;
+  image: string;
+  quantity: number;
+  unitPrice: number;
+  lineTotal: number;
+}
+
+export interface ResolvedCart {
+  lines: ResolvedCartLine[];
+  /** ids present in the stored cart that no longer match any canonical product. */
+  removedIds: string[];
+  total: number;
+}
+
+function catalogKey(id: string, type: ProductType): string {
+  return `${type}:${id}`;
+}
+
+export function buildCanonicalCatalog(
+  entries: Array<{
+    id: string;
+    type: ProductType;
+    title: string;
+    image: string;
+    price: number;
+    discount?: number;
+  }>
+): CanonicalProduct[] {
+  return entries.map((entry) => ({
+    id: entry.id,
+    type: entry.type,
+    title: entry.title,
+    image: entry.image,
+    price: calculateDiscountedPrice(entry.price, entry.discount ?? 0),
+  }));
+}
+
+/**
+ * Resolve a raw cart (id/type/quantity only) against the canonical catalog.
+ * Any cart entry that no longer matches a real product is dropped and its
+ * id reported in `removedIds` instead of being trusted for price/title.
+ */
+export function resolveCart(cart: CartItem[], catalog: CanonicalProduct[]): ResolvedCart {
+  const byKey = new Map(catalog.map((product) => [catalogKey(product.id, product.type), product]));
+
+  const lines: ResolvedCartLine[] = [];
+  const removedIds: string[] = [];
+
+  for (const item of cart) {
+    const product = byKey.get(catalogKey(item.id, item.type));
+    if (!product) {
+      removedIds.push(item.id);
+      continue;
+    }
+
+    lines.push({
+      id: product.id,
+      type: product.type,
+      title: product.title,
+      image: product.image,
+      quantity: item.quantity,
+      unitPrice: product.price,
+      lineTotal: product.price * item.quantity,
+    });
+  }
+
+  const total = lines.reduce((sum, line) => sum + line.lineTotal, 0);
+
+  return { lines, removedIds, total };
+}

--- a/src/utils/checkoutMessage.ts
+++ b/src/utils/checkoutMessage.ts
@@ -1,18 +1,31 @@
-import type { CartItem } from './cartManager';
+import type { ResolvedCartLine } from './catalogPricing';
 import { formatPEN } from './pricing';
 
 /**
- * Build the WhatsApp order message from the current cart contents.
- * Extracted from checkout.astro so the exact wording/format is unit-testable.
+ * Short, human-typeable id so the buyer and seller can both reference the
+ * same request when confirming payment/availability over WhatsApp.
  */
-export function buildWhatsAppMessage(cart: CartItem[], total: number): string {
-  let message = `*Nuevo pedido desde FluentReads*\n\n*Productos:*\n`;
+export function generateOrderRequestId(): string {
+  const random = Math.random().toString(36).slice(2, 6).toUpperCase();
+  return `FR-${Date.now().toString(36).toUpperCase()}${random}`;
+}
 
-  cart.forEach((item, index) => {
-    message += `${index + 1}. ${item.title} (${item.quantity}x) - ${formatPEN(item.price * item.quantity)}\n`;
+/**
+ * Build the WhatsApp order message from resolved cart lines (title/price
+ * already verified against the canonical catalog — never raw cart data).
+ */
+export function buildWhatsAppMessage(
+  lines: ResolvedCartLine[],
+  total: number,
+  requestId: string
+): string {
+  let message = `*Nuevo pedido desde FluentReads*\n*Ref: ${requestId}*\n\n*Productos:*\n`;
+
+  lines.forEach((line, index) => {
+    message += `${index + 1}. ${line.title} (${line.quantity}x) - ${formatPEN(line.lineTotal)}\n`;
   });
 
-  message += `\n*Total: ${formatPEN(total)}*\n\nPor favor, confirmame este pedido para enviarte los datos de pago. ¡Gracias!`;
+  message += `\n*Total: ${formatPEN(total)}*\n\nEsta es una solicitud de pedido pendiente de confirmación. El vendedor confirmará disponibilidad, contenido y total antes de recibir la transferencia. ¡Gracias!`;
 
   return message;
 }

--- a/tests/e2e/purchase-flow.spec.ts
+++ b/tests/e2e/purchase-flow.spec.ts
@@ -68,4 +68,63 @@ test.describe('Catalog to WhatsApp checkout', () => {
     await expect(page.locator('#empty-cart-message')).toBeVisible();
     await expect(page.locator('#cart-container')).toBeHidden();
   });
+
+  test('tampering with the stored price/title in localStorage has no effect on checkout', async ({
+    page,
+  }) => {
+    await page.goto('/catalogo');
+    await page.locator('a.book-cover-container').first().click();
+
+    const addToCartBtn = page.locator('.add-to-cart-btn').first();
+    const realTitle = await addToCartBtn.getAttribute('data-title');
+    const realPrice = Number(await addToCartBtn.getAttribute('data-price'));
+
+    await addToCartBtn.click();
+    await page.waitForFunction(() => {
+      const raw = localStorage.getItem('shoppingCart');
+      return !!raw && raw !== '[]';
+    });
+
+    // Only id/type/quantity should ever be persisted — confirm price/title
+    // never made it into localStorage in the first place...
+    const storedCart = await page.evaluate(() => JSON.parse(localStorage.getItem('shoppingCart')!));
+    expect(storedCart[0]).not.toHaveProperty('price');
+    expect(storedCart[0]).not.toHaveProperty('title');
+
+    // ...then simulate a bug or a malicious script editing it directly anyway.
+    await page.evaluate(() => {
+      const cart = JSON.parse(localStorage.getItem('shoppingCart')!);
+      cart[0].price = 0.01;
+      cart[0].title = 'TAMPERED FREE PRODUCT';
+      localStorage.setItem('shoppingCart', JSON.stringify(cart));
+    });
+
+    await page.goto('/checkout');
+    await page.waitForSelector('#cart-items h4');
+
+    await expect(page.locator('#cart-items')).toContainText(realTitle!);
+    await expect(page.locator('#cart-items')).not.toContainText('TAMPERED FREE PRODUCT');
+    await expect(page.locator('#cart-total')).toHaveText(`S/${realPrice.toFixed(2)}`);
+  });
+
+  test('a cart item pointing at a product that no longer exists is dropped with a visible notice', async ({
+    page,
+  }) => {
+    await page.goto('/');
+    await page.evaluate(() => {
+      localStorage.setItem(
+        'shoppingCart',
+        JSON.stringify([{ id: 'this-product-does-not-exist', type: 'book', quantity: 1 }])
+      );
+    });
+
+    await page.goto('/checkout');
+
+    await expect(page.locator('#empty-cart-message')).toBeVisible();
+    await expect(page.locator('#removed-items-notice')).toBeVisible();
+    await expect(page.locator('#removed-items-notice')).toContainText('ya no está disponible');
+
+    const storedCart = await page.evaluate(() => localStorage.getItem('shoppingCart'));
+    expect(storedCart).toBe('[]');
+  });
 });

--- a/tests/unit/cartManager.test.ts
+++ b/tests/unit/cartManager.test.ts
@@ -51,65 +51,135 @@ describe('CartManager.getCart', () => {
     localStorage.setItem('shoppingCart', '{not valid json');
     expect(CartManager.getCart()).toEqual([]);
   });
+
+  test('returns an empty array when the stored value is not an array', () => {
+    localStorage.setItem('shoppingCart', JSON.stringify({ not: 'an array' }));
+    expect(CartManager.getCart()).toEqual([]);
+  });
+
+  test('drops entries with an unknown product type', () => {
+    localStorage.setItem(
+      'shoppingCart',
+      JSON.stringify([{ id: 'b1', type: 'not-a-real-type', quantity: 1 }])
+    );
+    expect(CartManager.getCart()).toEqual([]);
+  });
+
+  test('drops entries with a non-positive or non-integer quantity', () => {
+    localStorage.setItem(
+      'shoppingCart',
+      JSON.stringify([
+        { id: 'b1', type: 'book', quantity: 0 },
+        { id: 'b2', type: 'book', quantity: -1 },
+        { id: 'b3', type: 'book', quantity: 1.5 },
+        { id: 'b4', type: 'book', quantity: 1000 },
+      ])
+    );
+    expect(CartManager.getCart()).toEqual([]);
+  });
+
+  test('drops entries carrying extra fields like price or title without trusting them', () => {
+    // A tampered localStorage value trying to smuggle a price back in.
+    localStorage.setItem(
+      'shoppingCart',
+      JSON.stringify([{ id: 'b1', type: 'book', quantity: 1, price: 0.01, title: 'Hacked' }])
+    );
+    const cart = CartManager.getCart();
+    expect(cart).toHaveLength(1);
+    // isValidCartItem doesn't strip extra keys, but nothing downstream reads
+    // them — CartItem's contract is id/type/quantity only.
+    expect(cart[0].id).toBe('b1');
+    expect(cart[0].quantity).toBe(1);
+  });
 });
 
 describe('CartManager.addItem', () => {
   test('adds a new item with quantity 1', () => {
-    CartManager.addItem({ id: 'b1', title: 'Book 1', price: 10, image: '/i.jpg', type: 'book' });
-    expect(CartManager.getCart()).toEqual([
-      { id: 'b1', title: 'Book 1', price: 10, image: '/i.jpg', type: 'book', quantity: 1 },
-    ]);
+    CartManager.addItem('b1', 'book');
+    expect(CartManager.getCart()).toEqual([{ id: 'b1', type: 'book', quantity: 1 }]);
   });
 
-  test('increments quantity when the same id is added again', () => {
-    const item = { id: 'b1', title: 'Book 1', price: 10, image: '/i.jpg', type: 'book' as const };
-    CartManager.addItem(item);
-    CartManager.addItem(item);
+  test('increments quantity when the same id+type is added again', () => {
+    CartManager.addItem('b1', 'book');
+    CartManager.addItem('b1', 'book');
     const cart = CartManager.getCart();
     expect(cart).toHaveLength(1);
     expect(cart[0].quantity).toBe(2);
   });
 
   test('keeps distinct entries for different ids', () => {
-    CartManager.addItem({ id: 'b1', title: 'Book 1', price: 10, image: '/i.jpg', type: 'book' });
-    CartManager.addItem({ id: 'p1', title: 'Pack 1', price: 20, image: '/i.jpg', type: 'pack' });
+    CartManager.addItem('b1', 'book');
+    CartManager.addItem('p1', 'pack');
     expect(CartManager.getCart()).toHaveLength(2);
+  });
+
+  test('keeps distinct entries when the same id is used across different types', () => {
+    CartManager.addItem('shared-id', 'book');
+    CartManager.addItem('shared-id', 'offer');
+    expect(CartManager.getCart()).toHaveLength(2);
+  });
+
+  test('does not increment quantity past MAX_QUANTITY', () => {
+    for (let i = 0; i < CartManager.MAX_QUANTITY + 10; i++) {
+      CartManager.addItem('b1', 'book');
+    }
+    expect(CartManager.getCart()[0].quantity).toBe(CartManager.MAX_QUANTITY);
   });
 });
 
 describe('CartManager.removeItem', () => {
   test('removes only the targeted item', () => {
-    CartManager.addItem({ id: 'b1', title: 'Book 1', price: 10, image: '/i.jpg', type: 'book' });
-    CartManager.addItem({ id: 'b2', title: 'Book 2', price: 15, image: '/i.jpg', type: 'book' });
-    CartManager.removeItem('b1');
+    CartManager.addItem('b1', 'book');
+    CartManager.addItem('b2', 'book');
+    CartManager.removeItem('b1', 'book');
     const cart = CartManager.getCart();
     expect(cart).toHaveLength(1);
     expect(cart[0].id).toBe('b2');
+  });
+
+  test('does not remove an item of a different type sharing the same id', () => {
+    CartManager.addItem('shared-id', 'book');
+    CartManager.addItem('shared-id', 'offer');
+    CartManager.removeItem('shared-id', 'book');
+    const cart = CartManager.getCart();
+    expect(cart).toEqual([{ id: 'shared-id', type: 'offer', quantity: 1 }]);
   });
 });
 
 describe('CartManager.updateQuantity', () => {
   test('updates the quantity of an existing item', () => {
-    CartManager.addItem({ id: 'b1', title: 'Book 1', price: 10, image: '/i.jpg', type: 'book' });
-    CartManager.updateQuantity('b1', 5);
+    CartManager.addItem('b1', 'book');
+    CartManager.updateQuantity('b1', 'book', 5);
     expect(CartManager.getCart()[0].quantity).toBe(5);
   });
 
   test('ignores updates to a quantity below 1', () => {
-    CartManager.addItem({ id: 'b1', title: 'Book 1', price: 10, image: '/i.jpg', type: 'book' });
-    CartManager.updateQuantity('b1', 0);
+    CartManager.addItem('b1', 'book');
+    CartManager.updateQuantity('b1', 'book', 0);
+    expect(CartManager.getCart()[0].quantity).toBe(1);
+  });
+
+  test('ignores non-integer quantities', () => {
+    CartManager.addItem('b1', 'book');
+    CartManager.updateQuantity('b1', 'book', 2.5);
+    expect(CartManager.getCart()[0].quantity).toBe(1);
+  });
+
+  test('ignores quantities above MAX_QUANTITY', () => {
+    CartManager.addItem('b1', 'book');
+    CartManager.updateQuantity('b1', 'book', CartManager.MAX_QUANTITY + 1);
     expect(CartManager.getCart()[0].quantity).toBe(1);
   });
 
   test('is a no-op for an id that is not in the cart', () => {
-    CartManager.updateQuantity('missing', 3);
+    CartManager.updateQuantity('missing', 'book', 3);
     expect(CartManager.getCart()).toEqual([]);
   });
 });
 
 describe('CartManager.clearCart', () => {
   test('empties the cart', () => {
-    CartManager.addItem({ id: 'b1', title: 'Book 1', price: 10, image: '/i.jpg', type: 'book' });
+    CartManager.addItem('b1', 'book');
     CartManager.clearCart();
     expect(CartManager.getCart()).toEqual([]);
   });
@@ -117,22 +187,9 @@ describe('CartManager.clearCart', () => {
 
 describe('CartManager.getItemCount', () => {
   test('sums quantities across all items', () => {
-    CartManager.addItem({ id: 'b1', title: 'Book 1', price: 10, image: '/i.jpg', type: 'book' });
-    CartManager.updateQuantity('b1', 3);
-    CartManager.addItem({ id: 'b2', title: 'Book 2', price: 10, image: '/i.jpg', type: 'book' });
+    CartManager.addItem('b1', 'book');
+    CartManager.updateQuantity('b1', 'book', 3);
+    CartManager.addItem('b2', 'book');
     expect(CartManager.getItemCount()).toBe(4);
-  });
-});
-
-describe('CartManager.getCartTotal', () => {
-  test('sums price * quantity across all items', () => {
-    CartManager.addItem({ id: 'b1', title: 'Book 1', price: 10, image: '/i.jpg', type: 'book' });
-    CartManager.updateQuantity('b1', 2);
-    CartManager.addItem({ id: 'b2', title: 'Book 2', price: 5, image: '/i.jpg', type: 'book' });
-    expect(CartManager.getCartTotal()).toBe(25);
-  });
-
-  test('returns 0 for an empty cart', () => {
-    expect(CartManager.getCartTotal()).toBe(0);
   });
 });

--- a/tests/unit/catalogPricing.test.ts
+++ b/tests/unit/catalogPricing.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  buildCanonicalCatalog,
+  resolveCart,
+  type CanonicalProduct,
+} from '../../src/utils/catalogPricing';
+import type { CartItem } from '../../src/utils/cartManager';
+
+const catalog: CanonicalProduct[] = buildCanonicalCatalog([
+  { id: 'book-1', type: 'book', title: 'Book One', image: '/book-1.jpg', price: 100, discount: 0 },
+  { id: 'book-2', type: 'book', title: 'Book Two', image: '/book-2.jpg', price: 50, discount: 20 },
+  { id: 'pack-1', type: 'pack', title: 'Pack One', image: '/pack-1.jpg', price: 200, discount: 10 },
+]);
+
+function cartItem(overrides: Partial<CartItem> = {}): CartItem {
+  return { id: 'book-1', type: 'book', quantity: 1, ...overrides };
+}
+
+describe('buildCanonicalCatalog', () => {
+  test('bakes the discount into the canonical price', () => {
+    const [, book2] = catalog;
+    expect(book2.price).toBeCloseTo(40, 5); // 50 * (1 - 20/100)
+  });
+
+  test('leaves an undiscounted price untouched', () => {
+    const [book1] = catalog;
+    expect(book1.price).toBe(100);
+  });
+});
+
+describe('resolveCart', () => {
+  test('resolves title/image/price from the catalog, not the cart item', () => {
+    const resolved = resolveCart([cartItem({ id: 'book-1', quantity: 2 })], catalog);
+
+    expect(resolved.lines).toEqual([
+      {
+        id: 'book-1',
+        type: 'book',
+        title: 'Book One',
+        image: '/book-1.jpg',
+        quantity: 2,
+        unitPrice: 100,
+        lineTotal: 200,
+      },
+    ]);
+    expect(resolved.total).toBe(200);
+    expect(resolved.removedIds).toEqual([]);
+  });
+
+  test('applies the catalog discount when computing the line total', () => {
+    const resolved = resolveCart([cartItem({ id: 'book-2', quantity: 3 })], catalog);
+
+    expect(resolved.lines[0].unitPrice).toBeCloseTo(40, 5);
+    expect(resolved.lines[0].lineTotal).toBeCloseTo(120, 5);
+  });
+
+  test('drops cart entries that no longer match any catalog product', () => {
+    const resolved = resolveCart(
+      [cartItem({ id: 'book-1' }), cartItem({ id: 'deleted-product' })],
+      catalog
+    );
+
+    expect(resolved.lines).toHaveLength(1);
+    expect(resolved.lines[0].id).toBe('book-1');
+    expect(resolved.removedIds).toEqual(['deleted-product']);
+  });
+
+  test('distinguishes products with the same id but different types', () => {
+    const catalogWithCollision: CanonicalProduct[] = buildCanonicalCatalog([
+      { id: 'shared-id', type: 'book', title: 'The Book', image: '/b.jpg', price: 10 },
+      { id: 'shared-id', type: 'offer', title: 'The Offer', image: '/o.jpg', price: 999 },
+    ]);
+
+    const resolved = resolveCart(
+      [cartItem({ id: 'shared-id', type: 'book' })],
+      catalogWithCollision
+    );
+
+    expect(resolved.lines).toHaveLength(1);
+    expect(resolved.lines[0].title).toBe('The Book');
+    expect(resolved.lines[0].unitPrice).toBe(10);
+  });
+
+  test('ignores a tampered price/title on the raw cart item entirely', () => {
+    // CartItem shouldn't even carry these fields, but simulate a
+    // maliciously-edited localStorage payload reaching resolveCart anyway.
+    const tampered = {
+      id: 'book-1',
+      type: 'book',
+      quantity: 1,
+      price: 0.01,
+      title: 'Hacked',
+    } as CartItem;
+
+    const resolved = resolveCart([tampered], catalog);
+
+    expect(resolved.lines[0].unitPrice).toBe(100);
+    expect(resolved.lines[0].title).toBe('Book One');
+  });
+
+  test('sums line totals across multiple products', () => {
+    const resolved = resolveCart(
+      [
+        cartItem({ id: 'book-1', quantity: 1 }),
+        cartItem({ id: 'pack-1', type: 'pack', quantity: 2 }),
+      ],
+      catalog
+    );
+
+    // book-1: 100 * 1 = 100; pack-1: (200 * 0.9) * 2 = 360
+    expect(resolved.total).toBeCloseTo(460, 5);
+  });
+
+  test('returns an empty result for an empty cart', () => {
+    const resolved = resolveCart([], catalog);
+    expect(resolved).toEqual({ lines: [], removedIds: [], total: 0 });
+  });
+});

--- a/tests/unit/checkoutMessage.test.ts
+++ b/tests/unit/checkoutMessage.test.ts
@@ -1,45 +1,78 @@
 import { describe, expect, test } from 'bun:test';
-import { buildWhatsAppMessage, buildWhatsAppUrl } from '../../src/utils/checkoutMessage';
-import type { CartItem } from '../../src/utils/cartManager';
+import {
+  buildWhatsAppMessage,
+  buildWhatsAppUrl,
+  generateOrderRequestId,
+} from '../../src/utils/checkoutMessage';
+import type { ResolvedCartLine } from '../../src/utils/catalogPricing';
 
-function item(overrides: Partial<CartItem> = {}): CartItem {
+function line(overrides: Partial<ResolvedCartLine> = {}): ResolvedCartLine {
   return {
     id: 'essential-grammar-advanced',
-    title: 'Essential Grammar Advanced',
-    price: 39.99,
-    image: '/img.jpg',
     type: 'book',
+    title: 'Essential Grammar Advanced',
+    image: '/img.jpg',
     quantity: 1,
+    unitPrice: 39.99,
+    lineTotal: 39.99,
     ...overrides,
   };
 }
 
 describe('buildWhatsAppMessage', () => {
-  test('lists every cart item with quantity and line total', () => {
-    const cart = [
-      item({ title: 'Book A', price: 10, quantity: 2 }),
-      item({ title: 'Book B', price: 5, quantity: 1 }),
+  test('lists every cart line with quantity and line total', () => {
+    const lines = [
+      line({ title: 'Book A', unitPrice: 10, quantity: 2, lineTotal: 20 }),
+      line({ title: 'Book B', unitPrice: 5, quantity: 1, lineTotal: 5 }),
     ];
 
-    const message = buildWhatsAppMessage(cart, 25);
+    const message = buildWhatsAppMessage(lines, 25, 'FR-TEST1234');
 
     expect(message).toContain('1. Book A (2x) - S/20.00');
     expect(message).toContain('2. Book B (1x) - S/5.00');
   });
 
-  test('includes the header and total footer', () => {
-    const message = buildWhatsAppMessage([item({ price: 10, quantity: 1 })], 10);
+  test('includes the header, request id, and total footer', () => {
+    const message = buildWhatsAppMessage(
+      [line({ unitPrice: 10, quantity: 1, lineTotal: 10 })],
+      10,
+      'FR-ABC123'
+    );
 
     expect(message).toStartWith('*Nuevo pedido desde FluentReads*');
+    expect(message).toContain('*Ref: FR-ABC123*');
     expect(message).toContain('*Total: S/10.00*');
-    expect(message).toContain('Por favor, confirmame este pedido');
+    expect(message).toContain('solicitud de pedido pendiente de confirmación');
   });
 
   test('produces just the header/total when the cart is empty', () => {
-    const message = buildWhatsAppMessage([], 0);
+    const message = buildWhatsAppMessage([], 0, 'FR-EMPTY01');
 
     expect(message).toContain('*Productos:*');
     expect(message).toContain('*Total: S/0.00*');
+  });
+
+  test('uses the pre-computed lineTotal rather than recomputing from unitPrice * quantity', () => {
+    // Guards against silently trusting a mismatched lineTotal/unitPrice pair
+    // instead of whatever resolveCart() actually computed.
+    const message = buildWhatsAppMessage(
+      [line({ unitPrice: 999, quantity: 1, lineTotal: 10 })],
+      10,
+      'FR-GUARD01'
+    );
+    expect(message).toContain('S/10.00');
+    expect(message).not.toContain('S/999.00');
+  });
+});
+
+describe('generateOrderRequestId', () => {
+  test('produces an FR-prefixed id', () => {
+    expect(generateOrderRequestId()).toMatch(/^FR-[A-Z0-9]+$/);
+  });
+
+  test('produces different ids on successive calls', () => {
+    const ids = new Set(Array.from({ length: 20 }, () => generateOrderRequestId()));
+    expect(ids.size).toBeGreaterThan(1);
   });
 });
 


### PR DESCRIPTION
## Summary

Resolves #54.

The cart persisted full `CartItem` objects — including `price` and `title` — straight to `localStorage`, and checkout trusted whatever was there. Any script or manual localStorage edit could change what a customer is charged and what the WhatsApp order message says, with zero indication anything was off.

### Changes

- **`CartManager`** now persists only `{id, type, quantity}`. `addItem`/`removeItem`/`updateQuantity` take `id`+`type` (composite key — two different product types can never collide on `id`) instead of a full item object. `getCart()` validates every stored entry (known type, positive integer quantity within a `MAX_QUANTITY` ceiling) and silently drops anything malformed rather than trusting it.
- **New `src/utils/catalogPricing.ts`**: `buildCanonicalCatalog()` turns Content Collection entries into a trusted `{id, type, title, image, price}` list (discount pre-applied), and `resolveCart()` maps a raw cart against it — any cart entry with no catalog match is reported in `removedIds` instead of being rendered with fallback/guessed values.
- **`checkout.astro`** now fetches `books`/`packs`/`exams`/`offers` via `getCollection()` at build time, embeds the resulting canonical catalog as a JSON data island, and resolves the cart against it client-side. Title, image, and price shown at checkout — and used to build the WhatsApp message/total — all come from this catalog, never from the stored cart item. Stale cart entries (deleted products) are removed from storage and surfaced via a visible notice.
- The five "add to cart" call sites (`BookDetails`/`PackDetails`/`ExamDetails`/`Card`/`PromoCard`) no longer read `data-price`/`data-title` into the cart — they only ever needed `id`+`type`.
- **`offers.json` is now a first-class product type (`'offer'`)** in the canonical catalog instead of being force-mapped to a guessed book/pack id that doesn't actually exist in those collections (confirmed via #51's catalog-integrity characterization tests). This was silently broken before: `PromoCard`'s "Comprar" button added a made-up cart entry with no real backing product — under the new model that would've just vanished from checkout as an "unavailable" item, so I fixed the underlying mismatch instead of letting a real feature quietly break.
- `buildWhatsAppMessage()` now takes resolved (trusted) cart lines instead of raw cart items, and includes a short order request id (`generateOrderRequestId()`) plus an explicit "pending confirmation" note, per the issue's asks for order traceability and clarity that the seller still confirms the final total.

### Real bug found while testing this live

The "removed items" notice was nested inside `#cart-container`, which gets hidden whenever the cart ends up empty — so a customer whose only cart item got dropped as invalid would never actually see why it disappeared. Caught this by driving the dev server with Playwright (not just unit tests) and checking actual rendered visibility. Moved the notice to a sibling element so it renders regardless of cart emptiness.

### Manually verified live (dev server + Playwright), not just asserted

- Added a real book to cart, confirmed `localStorage` only contains `{id, type, quantity}` — no price/title at all.
- Edited `localStorage` directly to set `price: 0.01` and `title: 'HACKED FREE BOOK'`, reloaded checkout: displayed title and total were unaffected (matched the real catalog price, not the tampered value).
- Set a cart entry pointing at a nonexistent product id: checkout shows the empty-cart state *and* the "no longer available" notice, and the invalid entry is cleaned out of `localStorage`.

## Test plan

- [x] `bun run format:check` / `lint` / `check` / `build` — all clean
- [x] `bun run test:unit` — 84/84 pass (added `catalogPricing.test.ts`, rewrote `cartManager.test.ts` and `checkoutMessage.test.ts` for the new shapes)
- [x] `bun run test:e2e` — 13/13 pass (added 2 new tests: tampering resistance, stale-product removal notice), run twice for stability — one flake in a 12-worker run was sandbox resource contention (passed reliably both single-worker and on rerun)
- [x] Manually verified live via Playwright against the dev server (see above) — this isn't something unit tests alone could catch, since it depends on real `getCollection()` output and real DOM rendering
