### PR TITLE
fix(navigation): remove or implement broken catalog category routes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,9 @@ jobs:
       - name: Build
         run: bun run build
 
+      - name: Check internal links
+        run: bun run check:links
+
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "test:unit": "bun test tests/unit",
     "test:e2e": "playwright test",
     "test": "bun run test:unit",
+    "check:links": "node scripts/check-internal-links.mjs",
     "prepare": "husky"
   },
   "dependencies": {

--- a/scripts/check-internal-links.mjs
+++ b/scripts/check-internal-links.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+/**
+ * Crawls the built site (dist/) and fails if any internal <a href="/..."> or
+ * <img src="/..."> points at a route/file that doesn't actually exist in the
+ * build output. Run after `astro build`. See issue #59.
+ */
+import { readdirSync, statSync, existsSync, readFileSync } from 'node:fs';
+import { extname, join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const DIST_DIR = fileURLToPath(new URL('../dist', import.meta.url));
+
+function walkHtmlFiles(dir) {
+  const files = [];
+  for (const entry of readdirSync(dir)) {
+    const fullPath = join(dir, entry);
+    const stats = statSync(fullPath);
+    if (stats.isDirectory()) {
+      files.push(...walkHtmlFiles(fullPath));
+    } else if (entry.endsWith('.html')) {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+function resolvesToFile(pathname) {
+  let cleanPath = pathname.split('#')[0].split('?')[0];
+  if (cleanPath === '') cleanPath = '/';
+
+  if (cleanPath.endsWith('/')) {
+    cleanPath += 'index.html';
+  } else if (!extname(cleanPath)) {
+    // Astro's default routing serves clean URLs (e.g. /sw.js) either as an
+    // exact file or as a directory with index.html.
+    if (existsSync(join(DIST_DIR, cleanPath))) return true;
+    cleanPath += '/index.html';
+  }
+
+  return existsSync(join(DIST_DIR, cleanPath));
+}
+
+function main() {
+  if (!existsSync(DIST_DIR)) {
+    console.error('dist/ not found — run `bun run build` first.');
+    process.exit(1);
+  }
+
+  const htmlFiles = walkHtmlFiles(DIST_DIR);
+  const linkPattern = /(?:href|src)="([^"]+)"/g;
+  /** @type {Map<string, Set<string>>} */
+  const brokenLinks = new Map();
+
+  for (const file of htmlFiles) {
+    const content = readFileSync(file, 'utf-8');
+    let match;
+    while ((match = linkPattern.exec(content))) {
+      const link = match[1];
+      // Only same-origin, path-absolute links — not external URLs, mailto:,
+      // tel:, anchors-only, or protocol-relative //external.
+      if (!link.startsWith('/') || link.startsWith('//')) continue;
+
+      if (!resolvesToFile(link)) {
+        const sourceFile = relative(DIST_DIR, file);
+        if (!brokenLinks.has(link)) brokenLinks.set(link, new Set());
+        brokenLinks.get(link).add(sourceFile);
+      }
+    }
+  }
+
+  if (brokenLinks.size === 0) {
+    console.log(`Checked ${htmlFiles.length} pages — no broken internal links found.`);
+    return;
+  }
+
+  console.error(
+    `Found ${brokenLinks.size} broken internal link(s) across ${htmlFiles.length} pages:\n`
+  );
+  for (const [link, sources] of brokenLinks) {
+    console.error(`  ${link}`);
+    for (const source of sources) {
+      console.error(`    <- ${source}`);
+    }
+  }
+  process.exit(1);
+}
+
+main();

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,4 +1,5 @@
 ---
+import { getCollection } from 'astro:content';
 const pageclipKey = import.meta.env.PUBLIC_PAGECLIP_KEY;
 const isNewsletterConfigured = !!pageclipKey;
 const actionUrl = isNewsletterConfigured
@@ -10,6 +11,12 @@ import '../styles/Footer.css';
 import { siteConfig } from '@config/site';
 
 const currentYear = new Date().getFullYear();
+
+// Category links come from the categories collection instead of being
+// hand-typed, so the footer can never link to a category that doesn't
+// actually exist as a catalog route. See issue #59.
+const categories = await getCollection('categories');
+
 const footerLinks = [
   {
     title: 'Navegación',
@@ -22,13 +29,10 @@ const footerLinks = [
   },
   {
     title: 'Categorías',
-    links: [
-      { text: 'Inglés para Negocios', url: '/catalogo/negocios' },
-      { text: 'Inglés Profesional', url: '/catalogo/profesional' },
-      { text: 'Gramática & Vocabulario', url: '/catalogo/gramatica' },
-      { text: 'Certificaciones', url: '/catalogo/certificaciones' },
-      { text: 'Materiales Didácticos', url: '/catalogo/didacticos' },
-    ],
+    links: categories.map((category) => ({
+      text: category.data.name,
+      url: category.data.link,
+    })),
   },
   {
     title: 'Ayuda',

--- a/src/components/PromoCard.astro
+++ b/src/components/PromoCard.astro
@@ -1,7 +1,6 @@
 ---
 import Button from './Button.astro';
 import DiscountBadge from './DiscountBadge.astro';
-import ArrowRightIcon from './icons/ArrowRight.astro';
 
 interface OfferProps {
   id?: string;
@@ -13,7 +12,6 @@ interface OfferProps {
   salePrice: number;
   image: string;
   link: string;
-  detailsLink?: string; // Optional details link
 }
 
 interface Props {
@@ -30,10 +28,6 @@ const { Offer, index, size = 'large' } = Astro.props;
 // single product).
 const offerId = Offer.id || (Offer.link ? Offer.link.replace('/checkout/', '') : '');
 const offerType = 'offer';
-
-// Default details link if not provided
-const detailsLink =
-  Offer.detailsLink || `/ofertas/${Offer.title.toLowerCase().replace(/\s+/g, '-')}`;
 
 // Animation delay based on index
 const animationDelay = `${(index % 3) * 0.15}s`;
@@ -122,25 +116,10 @@ const priceSize = isSmallLayout ? 'text-sm' : isMediumLayout ? 'text-base' : 'te
 
       <!-- Action buttons - full width -->
       <div class="flex w-full flex-wrap gap-1 sm:gap-2">
-        <!-- For small size, only show the buy button -->
-        {
-          !isSmallLayout && (
-            <Button
-              variant="outline"
-              size={buttonSize}
-              href={detailsLink}
-              class="flex flex-1 items-center justify-center"
-            >
-              {isSmallLayout ? '' : 'Detalles'}
-              <ArrowRightIcon class={`${isSmallLayout ? 'h-2 w-2' : 'ml-1 h-3 w-3'}`} />
-            </Button>
-          )
-        }
-
         <Button
           variant="primary"
           size={buttonSize}
-          class={`${isSmallLayout ? 'w-full' : 'flex-1'} flex items-center justify-center promo-add-to-cart cursor-pointer`}
+          class="promo-add-to-cart flex w-full flex-1 cursor-pointer items-center justify-center"
           data-id={offerId}
           data-title={Offer.title}
           data-price={Offer.salePrice}
@@ -188,17 +167,6 @@ const priceSize = isSmallLayout ? 'text-sm' : isMediumLayout ? 'text-base' : 'te
 
             {/* Action buttons */}
             <div class="ml-4 flex space-x-3">
-              {/* View Details Button */}
-              <Button
-                variant="outline"
-                size="small"
-                href={detailsLink}
-                class="group flex items-center gap-1"
-              >
-                Detalles
-                <ArrowRightIcon class="h-4 w-4 transform transition-transform group-hover:translate-x-1" />
-              </Button>
-
               {/* Buy Now Button */}
               <Button
                 variant="primary"

--- a/src/data/exams.json
+++ b/src/data/exams.json
@@ -63,8 +63,8 @@
     "formatTags": ["pdf"],
     "popularityTags": ["bestSeller"],
     "featured": false,
-    "buyLink": "/checkout/cambridge-fce-prep",
-    "detailsLink": "/catalogo/examenes-internacionales/cambridge-fce-prep",
+    "buyLink": "/checkout/cambridge-first-certification",
+    "detailsLink": "/catalogo/examenes-internacionales/cambridge-first-certification",
     "includedItems": [
       "Prácticas de speaking",
       "Ejercicios de grammar y vocabulary",

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,0 +1,37 @@
+---
+import Layout from '../layouts/Layout.astro';
+import Button from '../components/Button.astro';
+import SectionTitle from '../components/SectionTitle.astro';
+---
+
+<Layout
+  title="Página no encontrada | FluentReads"
+  description="La página que buscas no existe. Explora nuestro catálogo de libros y materiales para aprender inglés."
+>
+  <div class="mx-auto max-w-2xl px-4 py-20 text-center">
+    <div class="mb-4 text-6xl" aria-hidden="true">🔍</div>
+    <SectionTitle tag="h1">Página no encontrada</SectionTitle>
+    <p class="mt-4 mb-8 text-gray-500">
+      La página que buscas no existe o ha cambiado de dirección. Puedes seguir explorando nuestro
+      catálogo o contactarnos si crees que esto es un error.
+    </p>
+    <div class="flex flex-col justify-center gap-3 sm:flex-row">
+      <Button
+        variant="primary"
+        size="medium"
+        href="/catalogo"
+        class="inline-flex items-center justify-center"
+      >
+        Ver Catálogo
+      </Button>
+      <Button
+        variant="outline"
+        size="medium"
+        href="/contacto"
+        class="inline-flex items-center justify-center"
+      >
+        Contactar Soporte
+      </Button>
+    </div>
+  </div>
+</Layout>

--- a/tests/e2e/not-found.spec.ts
+++ b/tests/e2e/not-found.spec.ts
@@ -1,0 +1,33 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('404 page', () => {
+  test('shows a useful message with a CTA back to the catalog and contact', async ({ page }) => {
+    const response = await page.goto('/this-route-does-not-exist');
+    expect(response?.status()).toBe(404);
+
+    await expect(page.getByRole('heading', { name: /no encontrada/i })).toBeVisible();
+    await expect(page.getByRole('main').getByRole('link', { name: 'Ver Catálogo' })).toBeVisible();
+    await expect(
+      page.getByRole('main').getByRole('link', { name: 'Contactar Soporte' })
+    ).toBeVisible();
+  });
+});
+
+test.describe('Footer category links', () => {
+  test('every category link resolves to a real page, not a 404', async ({ page }) => {
+    await page.goto('/');
+
+    const categoryLinks = page.locator('footer a[href^="/catalogo/"]');
+    const count = await categoryLinks.count();
+    expect(count).toBeGreaterThan(0);
+
+    const hrefs = await categoryLinks.evaluateAll((links) =>
+      links.map((link) => link.getAttribute('href'))
+    );
+
+    for (const href of hrefs) {
+      const response = await page.goto(href!);
+      expect(response?.status(), `${href} should not 404`).toBe(200);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Resolves #59.

Built `scripts/check-internal-links.mjs` — crawls `dist/`, resolves every internal `href`/`src` against the actual build output — and ran it against the current site to get a real inventory instead of guessing. Found **8 distinct broken internal links**.

### What was actually broken

- **`Footer.astro`'s "Categorías" section** hardcoded 5 links (`/catalogo/negocios`, `/profesional`, `/gramatica`, `/certificaciones`, `/didacticos`) that never matched any real route — only `/catalogo/{libros,packs,examenes-internacionales}` exist. Replaced the hardcoded list with categories generated from the `categories` content collection, so this section can't drift from real routes again.
- **`exams.json`'s "Cambridge First Certification" entry** (id `cambridge-first-certification`) had `buyLink`/`detailsLink` both pointing at `.../cambridge-fce-prep` instead of matching its own id — a plain data typo, fixed to match.
- **`PromoCard.astro`'s "Detalles" button** linked to `/ofertas/<slug-of-title>`, but there's no `/ofertas/[slug].astro` detail page and building one is out of scope here. Removed the button rather than invent a destination — the card already shows title, description, and price inline, and "Comprar" (wired to checkout since #54) remains as the working CTA.

### Also added

- **`src/pages/404.astro`**: a real custom 404 with a heading, message, and CTA links to `/catalogo` and `/contacto`. Astro's default is a generic host 404 with no way back into the site — confirmed this didn't exist before.
- **Wired the crawler into CI**: added as a step in the `build` job right after `astro build` (needs `dist/` to exist). `build` is already a required status check, so a broken internal link now blocks merging automatically — per the issue's ask for "CI incluye una comprobación automática de enlaces internos."
- **`tests/e2e/not-found.spec.ts`**: confirms the 404 page actually returns HTTP 404 (not 200) and that every footer category link resolves to a real page.

## Test plan

- [x] `bun run format:check` / `lint` / `check` / `build` — all clean
- [x] `bun run check:links` — 0 broken links across 31 pages (was 8 before this PR)
- [x] `bun run test:unit` — 84/84 pass (unaffected)
- [x] `bun run test:e2e` — 16/16 pass, run twice for stability (some parallel-load flakiness in this sandbox on unrelated tests, reproduced clean on rerun and in isolation)
