### PR TITLE
fix(seo): correct social metadata and remove unsupported structured data claims

### DIFF
--- a/src/components/details/BookDetails.astro
+++ b/src/components/details/BookDetails.astro
@@ -96,34 +96,13 @@ const shareTitle = book.title;
 const shareDescription =
   book.description.substring(0, 100) + (book.description.length > 100 ? '...' : '');
 const shareImage = book.coverImage;
-
-// SEO JSON-LD
-const jsonLd = {
-  '@context': 'https://schema.org',
-  '@type': 'Book',
-  name: book.title,
-  description: book.description,
-  image: book.coverImage,
-  offers: {
-    '@type': 'Offer',
-    price: discountedPrice,
-    priceCurrency: 'PEN',
-    availability: 'https://schema.org/InStock',
-  },
-  aggregateRating: book.rating
-    ? {
-        '@type': 'AggregateRating',
-        ratingValue: book.rating.score,
-        reviewCount: book.rating.reviewCount,
-      }
-    : undefined,
-};
 ---
 
+<!-- JSON-LD for this page is already emitted by Layout.astro (fed from
+     src/pages/catalogo/libros/[id].astro's structuredData prop) — this
+     component used to emit a second, duplicate/conflicting Book schema
+     with an unverified aggregateRating. See issue #58. -->
 <div class="product-detail-container bg-gray-50">
-  <!-- JSON-LD Schema for SEO -->
-  <script type="application/ld+json" set:html={JSON.stringify(jsonLd)} is:inline />
-
   <div class="mx-auto max-w-6xl px-4 py-6 sm:px-6 md:py-8">
     <!-- Breadcrumbs -->
     <nav

--- a/src/components/details/ExamDetails.astro
+++ b/src/components/details/ExamDetails.astro
@@ -92,35 +92,13 @@ const shareTitle = exam.title;
 const shareDescription =
   exam.description.substring(0, 100) + (exam.description.length > 100 ? '...' : '');
 const shareImage = exam.coverImage;
-
-// SEO JSON-LD
-const jsonLd = {
-  '@context': 'https://schema.org',
-  '@type': 'Product',
-  name: exam.title,
-  description: exam.description,
-  image: exam.coverImage,
-  offers: {
-    '@type': 'Offer',
-    price: discountedPrice,
-    priceCurrency: 'PEN',
-    availability: 'https://schema.org/InStock',
-  },
-  category: `Examen ${exam.examType}`,
-  aggregateRating: exam.rating
-    ? {
-        '@type': 'AggregateRating',
-        ratingValue: exam.rating.score,
-        reviewCount: exam.rating.reviewCount,
-      }
-    : undefined,
-};
 ---
 
+<!-- JSON-LD for this page is already emitted by Layout.astro (fed from
+     src/pages/catalogo/examenes-internacionales/[id].astro's structuredData
+     prop) — this component used to emit a second, duplicate/conflicting
+     Product schema with an unverified aggregateRating. See issue #58. -->
 <div class="product-detail-container bg-gray-50">
-  <!-- JSON-LD Schema for SEO -->
-  <script type="application/ld+json" set:html={JSON.stringify(jsonLd)} is:inline />
-
   <div class="mx-auto max-w-6xl px-4 py-6 sm:px-6 md:py-8">
     <!-- Breadcrumbs -->
     <nav

--- a/src/components/details/PackDetails.astro
+++ b/src/components/details/PackDetails.astro
@@ -103,34 +103,13 @@ const shareTitle = pack.title;
 const shareDescription =
   pack.description.substring(0, 100) + (pack.description.length > 100 ? '...' : '');
 const shareImage = pack.coverImage;
-
-// SEO JSON-LD
-const jsonLd = {
-  '@context': 'https://schema.org',
-  '@type': 'Product',
-  name: pack.title,
-  description: pack.description,
-  image: pack.coverImage,
-  offers: {
-    '@type': 'Offer',
-    price: discountedPrice,
-    priceCurrency: 'PEN',
-    availability: 'https://schema.org/InStock',
-  },
-  aggregateRating: pack.rating
-    ? {
-        '@type': 'AggregateRating',
-        ratingValue: pack.rating.score,
-        reviewCount: pack.rating.reviewCount,
-      }
-    : undefined,
-};
 ---
 
+<!-- JSON-LD for this page is already emitted by Layout.astro (fed from
+     src/pages/catalogo/packs/[id].astro's structuredData prop) — this
+     component used to emit a second, duplicate/conflicting Product schema
+     with an unverified aggregateRating. See issue #58. -->
 <div class="product-detail-container bg-gray-50">
-  <!-- JSON-LD Schema for SEO -->
-  <script type="application/ld+json" set:html={JSON.stringify(jsonLd)} is:inline />
-
   <div class="mx-auto max-w-6xl px-4 py-6 sm:px-6 md:py-8">
     <!-- Breadcrumbs -->
     <nav

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -152,26 +152,29 @@ const finalBreadcrumbData =
   });
 
 // Meta Tags Unificados
-const metaData = {
-  og: {
-    type: ogType,
-    url: absoluteCanonicalUrl,
-    title: ogTitle,
-    description: ogDescription,
-    image: absoluteOgImage,
-    siteName: ogSiteName,
-    imageWidth: imageWidth.toString(),
-    imageHeight: imageHeight.toString(),
-  },
-  twitter: {
-    card: twitterCard,
-    url: absoluteCanonicalUrl,
-    title: twitterTitle,
-    description: twitterDescription,
-    image: absoluteTwitterImage,
-    site: twitterSite,
-  },
-};
+// Open Graph property names are explicit here (not derived from camelCase
+// keys) because "og:site_name"/"og:image:width"/"og:image:height" don't
+// follow the same casing/separator convention as the rest — a naive
+// `og:${camelCaseKey}` mapping previously produced invalid properties like
+// "og:siteName" and "og:imageWidth" that crawlers don't recognize.
+const ogMeta: [string, string][] = [
+  ['og:type', ogType],
+  ['og:url', absoluteCanonicalUrl],
+  ['og:title', ogTitle],
+  ['og:description', ogDescription],
+  ['og:image', absoluteOgImage],
+  ['og:site_name', ogSiteName],
+  ['og:image:width', imageWidth.toString()],
+  ['og:image:height', imageHeight.toString()],
+];
+
+const twitterMeta: [string, string][] = [
+  ['twitter:card', twitterCard],
+  ['twitter:title', twitterTitle],
+  ['twitter:description', twitterDescription],
+  ['twitter:image', absoluteTwitterImage],
+  ['twitter:site', twitterSite],
+];
 ---
 
 <!doctype html>
@@ -208,18 +211,10 @@ const metaData = {
     />
 
     <!-- Open Graph / WhatsApp / Facebook -->
-    {
-      Object.entries(metaData.og).map(([key, value]) => (
-        <meta property={`og:${key}`} content={value} />
-      ))
-    }
+    {ogMeta.map(([property, content]) => <meta property={property} content={content} />)}
 
     <!-- Twitter Cards -->
-    {
-      Object.entries(metaData.twitter).map(([key, value]) => (
-        <meta name={`twitter:${key}`} content={value} />
-      ))
-    }
+    {twitterMeta.map(([name, content]) => <meta name={name} content={content} />)}
 
     <!-- Meta Tags para WhatsApp (Precio del Producto) -->
     {

--- a/src/pages/catalogo/examenes-internacionales/[id].astro
+++ b/src/pages/catalogo/examenes-internacionales/[id].astro
@@ -61,7 +61,10 @@ const description =
 const siteUrl = new URL(siteConfig.url);
 const canonicalURL = new URL(`/catalogo/examenes-internacionales/${exam.id}`, siteUrl);
 
-// Structured data for rich snippets
+// Structured data for rich snippets. No priceValidUntil (there's no actual
+// expiring offer to report), no aggregateRating (the rating in exams.json
+// isn't backed by verified, visible reviews) — emitting either would be an
+// unsupported claim to search engines. See issue #58.
 const structuredData = {
   '@context': 'https://schema.org',
   '@type': 'Product',
@@ -75,23 +78,11 @@ const structuredData = {
     priceCurrency: 'PEN',
     availability: 'https://schema.org/InStock',
     url: canonicalURL.toString(),
-    priceValidUntil: new Date(new Date().setFullYear(new Date().getFullYear() + 1))
-      .toISOString()
-      .split('T')[0],
   },
   brand: {
     '@type': 'Brand',
     name: exam.examType || siteInfo.siteName,
   },
-  aggregateRating: exam.rating
-    ? {
-        '@type': 'AggregateRating',
-        ratingValue: exam.rating.score,
-        reviewCount: exam.rating.reviewCount,
-        bestRating: '5',
-        worstRating: '1',
-      }
-    : undefined,
 };
 
 // Breadcrumb structured data

--- a/src/pages/catalogo/libros/[id].astro
+++ b/src/pages/catalogo/libros/[id].astro
@@ -60,38 +60,29 @@ const description =
 const siteUrl = new URL(siteConfig.url);
 const canonicalURL = new URL(`/catalogo/libros/${book.id}`, siteUrl);
 
-// Structured data for rich snippets
+// Structured data for rich snippets. No isbn (the book's internal id isn't
+// a real ISBN), no priceValidUntil (there's no actual expiring offer to
+// report), no aggregateRating (the rating in books.json isn't backed by
+// verified, visible reviews) — emitting any of these would be an unsupported
+// claim to search engines. See issue #58.
 const structuredData = {
   '@context': 'https://schema.org',
   '@type': 'Book',
   name: book.title,
   description: book.description,
   image: book.coverImage,
-  isbn: book.id, // Using ID as ISBN for example
   offers: {
     '@type': 'Offer',
     price: discountedPrice,
     priceCurrency: 'PEN',
     availability: 'https://schema.org/InStock',
     url: canonicalURL.toString(),
-    priceValidUntil: new Date(new Date().setFullYear(new Date().getFullYear() + 1))
-      .toISOString()
-      .split('T')[0],
   },
   publisher: {
     '@type': 'Organization',
     name: book.editorialId || siteInfo.siteName,
   },
   inLanguage: 'en',
-  aggregateRating: book.rating
-    ? {
-        '@type': 'AggregateRating',
-        ratingValue: book.rating.score,
-        reviewCount: book.rating.reviewCount,
-        bestRating: '5',
-        worstRating: '1',
-      }
-    : undefined,
 };
 
 // Breadcrumb structured data

--- a/src/pages/catalogo/packs/[id].astro
+++ b/src/pages/catalogo/packs/[id].astro
@@ -63,7 +63,10 @@ const description =
 const siteUrl = new URL(siteConfig.url);
 const canonicalURL = new URL(`/catalogo/packs/${pack.id}`, siteUrl);
 
-// Structured data for rich snippets
+// Structured data for rich snippets. No priceValidUntil (there's no actual
+// expiring offer to report), no aggregateRating (the rating in packs.json
+// isn't backed by verified, visible reviews) — emitting either would be an
+// unsupported claim to search engines. See issue #58.
 const structuredData = {
   '@context': 'https://schema.org',
   '@type': 'Product',
@@ -77,23 +80,11 @@ const structuredData = {
     priceCurrency: 'PEN',
     availability: 'https://schema.org/InStock',
     url: canonicalURL.toString(),
-    priceValidUntil: new Date(new Date().setFullYear(new Date().getFullYear() + 1))
-      .toISOString()
-      .split('T')[0],
   },
   brand: {
     '@type': 'Brand',
     name: siteInfo.siteName,
   },
-  aggregateRating: pack.rating
-    ? {
-        '@type': 'AggregateRating',
-        ratingValue: pack.rating.score,
-        reviewCount: pack.rating.reviewCount,
-        bestRating: '5',
-        worstRating: '1',
-      }
-    : undefined,
 };
 
 // Breadcrumb structured data

--- a/tests/e2e/seo-metadata.spec.ts
+++ b/tests/e2e/seo-metadata.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('SEO metadata', () => {
+  test('home page uses standard Open Graph property names, not camelCase', async ({ page }) => {
+    await page.goto('/');
+
+    // These are the correct standard names; the bug produced
+    // og:siteName/og:imageWidth/og:imageHeight instead.
+    await expect(page.locator('meta[property="og:site_name"]')).toHaveCount(1);
+    await expect(page.locator('meta[property="og:image:width"]')).toHaveCount(1);
+    await expect(page.locator('meta[property="og:image:height"]')).toHaveCount(1);
+
+    await expect(page.locator('meta[property="og:siteName"]')).toHaveCount(0);
+    await expect(page.locator('meta[property="og:imageWidth"]')).toHaveCount(0);
+    await expect(page.locator('meta[property="og:imageHeight"]')).toHaveCount(0);
+  });
+
+  test('a book detail page emits exactly one Book/Product JSON-LD block, with no fabricated claims', async ({
+    page,
+  }) => {
+    await page.goto('/catalogo');
+    await page.locator('a.book-cover-container').first().click();
+
+    const jsonLdBlocks = await page
+      .locator('script[type="application/ld+json"]')
+      .evaluateAll((scripts) => scripts.map((s) => JSON.parse(s.textContent || '{}')));
+
+    const productBlocks = jsonLdBlocks.filter(
+      (block) => block['@type'] === 'Book' || block['@type'] === 'Product'
+    );
+    expect(productBlocks).toHaveLength(1);
+
+    const product = productBlocks[0];
+    expect(product).not.toHaveProperty('isbn');
+    expect(product).not.toHaveProperty('aggregateRating');
+    expect(product.offers).not.toHaveProperty('priceValidUntil');
+  });
+});


### PR DESCRIPTION
## Summary

Resolves #58.

### Open Graph casing bug

`Layout.astro` built OG tags from a generic `Object.entries(metaData.og).map(([key]) => \`og:${key}\`)`, which produced invalid property names wherever the key wasn't already a single lowercase word: `og:siteName` and `og:imageWidth`/`og:imageHeight` instead of the actual standard `og:site_name` and `og:image:width`/`og:image:height`. Replaced the generic mapping with an explicit `[property, content]` list, so every emitted property name is one that actually exists in the Open Graph spec. Also dropped `twitter:url` from the Twitter Card tags — it's not a real Twitter Card property (the standard set is `card`/`site`/`creator`/`title`/`description`/`image`/`image:alt`), and wasn't doing anything but adding noise.

### Fabricated structured data claims

Removed from the three product detail pages' JSON-LD (books/packs/exams):
- `isbn: book.id` — the code comment literally said *"Using ID as ISBN for example."* An internal id is not a real ISBN.
- `priceValidUntil` computed as exactly one year from build time — not tied to any actual expiring offer, just a made-up future date.
- `aggregateRating` built straight from the rating numbers in `books/packs/exams.json` — those aren't backed by verified, visible reviews, so publishing them as `schema.org` `AggregateRating` is an unsupported claim to search engines (Google's structured data guidelines require ratings be tied to real review content).

### Real bug found while fixing the above

`BookDetails.astro`, `PackDetails.astro`, and `ExamDetails.astro` each **independently built and emitted their own second** `application/ld+json` script tag — a full second Book/Product schema block, duplicating (and conflicting with, once the fixes above landed) the one `Layout.astro` already emits from the page's `structuredData` prop. **Every product detail page was shipping two different structured-data blocks for the same entity.** Removed the component-level duplicate entirely — `Layout.astro`'s is the single source now.

### How I verified this

Parsed the actual JSON-LD out of a **built** book detail page's `dist/` HTML (not just reasoning about the source) and confirmed exactly one `Book` block with no `isbn`/`priceValidUntil`/`aggregateRating`, plus the separate `BreadcrumbList` block (expected — that's a different schema type, not a duplicate). Added `tests/e2e/seo-metadata.spec.ts` to keep both the OG casing and the single-JSON-LD-block contract covered going forward.

## Deferred

`organizationInfo` (address, foundingDate) in `page-information.json`, emitted as `Organization` JSON-LD on the home/contact pages, is also placeholder data — but that's a #53 problem (needs real business data I don't have), not a #58 "wrong schema/casing" problem. Left untouched; the JSON-LD structure itself is valid, only the values are placeholders.

## Test plan

- [x] `bun run format:check` / `lint` / `check` / `build` — all clean
- [x] `bun run check:links` — 0 broken links (unaffected)
- [x] `bun run test:unit` — 84/84 pass (unaffected)
- [x] `bun run test:e2e` — 18/18 pass, run twice for stability (some parallel-load flakiness on unrelated tests in this sandbox, reproduced clean on rerun)
- [x] Manually parsed JSON-LD from the built `dist/` HTML to confirm the fix at the actual output level, not just the template source
EOF
