### PR TITLE
perf(catalog): remove artificial latency and make featured content deterministic

### DIFF
--- a/src/components/catalog/CatalogBookContainer.astro
+++ b/src/components/catalog/CatalogBookContainer.astro
@@ -202,8 +202,9 @@ const showSkeletonOnLoad = useSkeleton && filteredBooks.length > 10;
       book.classList.add('hidden');
     });
 
-    // Simulate a loading delay
-    setTimeout(() => {
+    // Filtering runs over an in-memory array already on the page — there's
+    // no real async work here, so no artificial delay before it (see #62).
+    (() => {
       let visibleCount = 0;
 
       // Process the books based on filters
@@ -298,7 +299,7 @@ const showSkeletonOnLoad = useSkeleton && filteredBooks.length > 10;
         booksGrid.style.position = 'static';
         booksGrid.style.visibility = 'visible';
       }
-    }, 600);
+    })();
   };
 
   // Filter change event handler
@@ -340,16 +341,15 @@ const showSkeletonOnLoad = useSkeleton && filteredBooks.length > 10;
     const booksGrid = document.getElementById('books-grid');
 
     if (booksContainer && booksContainer.getAttribute('data-is-loading') === 'true') {
-      // Simulate loading delay
-      setTimeout(() => {
-        if (skeletonLoader) skeletonLoader.style.opacity = '0';
-        if (booksGrid) {
-          booksGrid.classList.remove('opacity-0');
-          booksGrid.style.position = 'static';
-          booksGrid.style.visibility = 'visible';
-        }
-        booksContainer.setAttribute('data-is-loading', 'false');
-      }, 1000);
+      // The grid is already server-rendered — reveal it immediately
+      // instead of holding the skeleton up with an artificial delay (#62).
+      if (skeletonLoader) skeletonLoader.style.opacity = '0';
+      if (booksGrid) {
+        booksGrid.classList.remove('opacity-0');
+        booksGrid.style.position = 'static';
+        booksGrid.style.visibility = 'visible';
+      }
+      booksContainer.setAttribute('data-is-loading', 'false');
     }
   });
 </script>

--- a/src/components/catalog/CatalogContainer.astro
+++ b/src/components/catalog/CatalogContainer.astro
@@ -293,8 +293,9 @@ const gridClass = getGridClassFromColumns(gridCols);
     ): void => {
       showLoading(true);
 
-      // Incrementa el retraso para dar tiempo a ver el skeleton
-      setTimeout(() => {
+      // Filtering runs over an in-memory array already on the page — there's
+      // no real async work here, so no artificial delay before it (see #62).
+      (() => {
         // Apply filters
         let filtered = [...allProducts];
 
@@ -329,21 +330,6 @@ const gridClass = getGridClassFromColumns(gridCols);
           filtered = filtered.filter((product) =>
             product.title.toLowerCase().includes(normalizedSearchTerm)
           );
-        }
-
-        // Debug logs
-        console.log(`Filtered to ${filtered.length} products`);
-        console.log(`Resource type filter: ${resourceType}`);
-        if (resourceType !== 'any') {
-          const typeCounts = filtered.reduce(
-            (acc, product) => {
-              acc[product.productType] = (acc[product.productType] || 0) + 1;
-              return acc;
-            },
-            {} as Record<string, number>
-          );
-
-          console.log('Products by type:', typeCounts);
         }
 
         // Apply sorting
@@ -419,7 +405,7 @@ const gridClass = getGridClassFromColumns(gridCols);
             detail: { count: visibleCount },
           })
         );
-      }, 600); // Aumentamos el retraso para apreciar mejor el skeleton
+      })();
     };
 
     // Filter change event handler - THIS IS THE KEY PART

--- a/src/components/catalog/CatalogExamContainer.astro
+++ b/src/components/catalog/CatalogExamContainer.astro
@@ -212,9 +212,9 @@ const showSkeletonOnLoad = useSkeleton && filteredExams.length > 8;
         card.classList.add('hidden');
       });
 
-      // Perform the actual filtering with a deliberate delay
-      // to allow the skeleton loader to be visible
-      setTimeout(() => {
+      // Filtering runs over an in-memory array already on the page — there's
+      // no real async work here, so no artificial delay before it (see #62).
+      (() => {
         let filteredExams = [...initialExams];
         let visibleCount = 0;
 
@@ -306,28 +306,28 @@ const showSkeletonOnLoad = useSkeleton && filteredExams.length > 8;
           }
         }
 
-        // Remove loading state with a slight delay for animation
-        setTimeout(() => {
-          document.body.classList.remove('filters-loading');
+        // Remove loading state
+        document.body.classList.remove('filters-loading');
 
-          if (examsContainer) {
-            examsContainer.setAttribute('data-is-loading', 'false');
-          }
+        if (examsContainer) {
+          examsContainer.setAttribute('data-is-loading', 'false');
+        }
 
-          if (skeletonLoader) {
-            skeletonLoader.style.opacity = '0';
-            setTimeout(() => {
-              skeletonLoader.style.display = 'none';
-            }, 300); // Short delay for fade out animation
-          }
+        if (skeletonLoader) {
+          skeletonLoader.style.opacity = '0';
+          // Kept: matches the skeleton's actual CSS opacity transition
+          // duration, unlike the artificial delays removed above.
+          setTimeout(() => {
+            skeletonLoader.style.display = 'none';
+          }, 300);
+        }
 
-          if (examsGrid) {
-            examsGrid.classList.remove('opacity-0');
-            examsGrid.style.position = 'static';
-            examsGrid.style.visibility = 'visible';
-          }
-        }, 300);
-      }, 600); // Deliberate delay to show skeleton loader
+        if (examsGrid) {
+          examsGrid.classList.remove('opacity-0');
+          examsGrid.style.position = 'static';
+          examsGrid.style.visibility = 'visible';
+        }
+      })();
     }
 
     // Listen for filter changes from Filter component
@@ -402,22 +402,21 @@ const showSkeletonOnLoad = useSkeleton && filteredExams.length > 8;
       observer.observe(card);
     });
 
-    // Simulation for initial loading if needed
+    // The grid is already server-rendered — reveal it immediately instead
+    // of holding the skeleton up with an artificial delay (#62).
     if (examsContainer && examsContainer.getAttribute('data-is-loading') === 'true') {
-      setTimeout(() => {
-        if (skeletonLoader) skeletonLoader.style.opacity = '0';
-        if (examsGrid) {
-          examsGrid.classList.remove('opacity-0');
-          examsGrid.style.position = 'static';
-          examsGrid.style.visibility = 'visible';
-        }
-        examsContainer.setAttribute('data-is-loading', 'false');
+      if (skeletonLoader) skeletonLoader.style.opacity = '0';
+      if (examsGrid) {
+        examsGrid.classList.remove('opacity-0');
+        examsGrid.style.position = 'static';
+        examsGrid.style.visibility = 'visible';
+      }
+      examsContainer.setAttribute('data-is-loading', 'false');
 
-        // Hide skeleton after fade out completes
-        setTimeout(() => {
-          if (skeletonLoader) skeletonLoader.style.display = 'none';
-        }, 300);
-      }, 800);
+      // Kept: matches the skeleton's actual CSS opacity transition duration.
+      setTimeout(() => {
+        if (skeletonLoader) skeletonLoader.style.display = 'none';
+      }, 300);
     }
   });
 </script>

--- a/src/components/catalog/CatalogPackContainer.astro
+++ b/src/components/catalog/CatalogPackContainer.astro
@@ -197,8 +197,9 @@ const showSkeletonOnLoad = useSkeleton && filteredPacks.length > 8;
       pack.classList.add('hidden');
     });
 
-    // Simulate a loading delay
-    setTimeout(() => {
+    // Filtering runs over an in-memory array already on the page — there's
+    // no real async work here, so no artificial delay before it (see #62).
+    (() => {
       let visibleCount = 0;
 
       // Process the packs based on filters
@@ -276,37 +277,37 @@ const showSkeletonOnLoad = useSkeleton && filteredPacks.length > 8;
         }
       }
 
-      // Remove loading state and hide skeleton with a slight delay for animation
-      setTimeout(() => {
-        document.body.classList.remove('filters-loading');
+      // Remove loading state and hide skeleton
+      document.body.classList.remove('filters-loading');
 
-        if (packsContainer) {
-          packsContainer.setAttribute('data-is-loading', 'false');
-        }
+      if (packsContainer) {
+        packsContainer.setAttribute('data-is-loading', 'false');
+      }
 
-        if (skeletonLoader) {
-          skeletonLoader.style.opacity = '0';
-          setTimeout(() => {
-            skeletonLoader.style.display = 'none';
-          }, 300); // Short delay for fade out animation
-        }
+      if (skeletonLoader) {
+        skeletonLoader.style.opacity = '0';
+        // Kept: matches the skeleton's actual CSS opacity transition
+        // duration, unlike the artificial delays removed above.
+        setTimeout(() => {
+          skeletonLoader.style.display = 'none';
+        }, 300);
+      }
 
-        if (packsGrid) {
-          packsGrid.classList.remove('opacity-0');
-          packsGrid.style.position = 'static';
-          packsGrid.style.visibility = 'visible';
+      if (packsGrid) {
+        packsGrid.classList.remove('opacity-0');
+        packsGrid.style.position = 'static';
+        packsGrid.style.visibility = 'visible';
 
-          // Reset animation for visible packs
-          const visiblePacks = document.querySelectorAll('.catalog-product-card:not(.hidden)');
-          visiblePacks.forEach((pack, index) => {
-            if (pack instanceof HTMLElement) {
-              pack.style.animationDelay = `${0.05 * index}s`;
-              pack.style.animationPlayState = 'running';
-            }
-          });
-        }
-      }, 300); // Add a slight delay for smoother transition
-    }, 600);
+        // Reset animation for visible packs
+        const visiblePacks = document.querySelectorAll('.catalog-product-card:not(.hidden)');
+        visiblePacks.forEach((pack, index) => {
+          if (pack instanceof HTMLElement) {
+            pack.style.animationDelay = `${0.05 * index}s`;
+            pack.style.animationPlayState = 'running';
+          }
+        });
+      }
+    })();
   };
 
   // Filter change event handler
@@ -348,21 +349,20 @@ const showSkeletonOnLoad = useSkeleton && filteredPacks.length > 8;
     const packsGrid = document.getElementById('packs-grid') as HTMLElement;
 
     if (packsContainer && packsContainer.getAttribute('data-is-loading') === 'true') {
-      // Simulate loading delay
-      setTimeout(() => {
-        if (skeletonLoader) skeletonLoader.style.opacity = '0';
-        if (packsGrid) {
-          packsGrid.classList.remove('opacity-0');
-          packsGrid.style.position = 'static';
-          packsGrid.style.visibility = 'visible';
-        }
-        packsContainer.setAttribute('data-is-loading', 'false');
+      // The grid is already server-rendered — reveal it immediately
+      // instead of holding the skeleton up with an artificial delay (#62).
+      if (skeletonLoader) skeletonLoader.style.opacity = '0';
+      if (packsGrid) {
+        packsGrid.classList.remove('opacity-0');
+        packsGrid.style.position = 'static';
+        packsGrid.style.visibility = 'visible';
+      }
+      packsContainer.setAttribute('data-is-loading', 'false');
 
-        // Hide skeleton after fade out completes
-        setTimeout(() => {
-          if (skeletonLoader) skeletonLoader.style.display = 'none';
-        }, 300);
-      }, 1000);
+      // Kept: matches the skeleton's actual CSS opacity transition duration.
+      setTimeout(() => {
+        if (skeletonLoader) skeletonLoader.style.display = 'none';
+      }, 300);
     }
   });
 </script>

--- a/src/utils/listProducts.ts
+++ b/src/utils/listProducts.ts
@@ -38,32 +38,6 @@ export function getAllProducts(): Product[] {
 }
 
 /**
- * Get a random selection of products
- * @param count Number of products to return
- * @param filterFn Optional filter function to apply
- * @returns Array of random products
- */
-export function getRandomProducts(
-  count: number,
-  filterFn?: (product: Product) => boolean
-): Product[] {
-  const allProducts = getAllProducts();
-
-  // Apply filter if provided
-  const filteredProducts = filterFn ? allProducts.filter(filterFn) : allProducts;
-
-  // Shuffle the products array using Fisher-Yates algorithm
-  const shuffled = [...filteredProducts];
-  for (let i = shuffled.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1));
-    [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
-  }
-
-  // Return the requested number of products, or all if count exceeds available products
-  return shuffled.slice(0, Math.min(count, shuffled.length));
-}
-
-/**
  * Get products filtered by type
  * @param type Product type to filter by ('book', 'pack', or 'exam')
  * @param count Maximum number of products to return (optional)
@@ -81,19 +55,6 @@ export function getProductsByType(type: 'book' | 'pack' | 'exam', count?: number
 }
 
 /**
- * Get featured products across all types or of a specific type
- * @param count Number of featured products to return
- * @param type Optional product type to filter by
- * @returns Array of featured products
- */
-export function getFeaturedProducts(count: number, type?: 'book' | 'pack' | 'exam'): Product[] {
-  return getRandomProducts(count, (product) => {
-    const typeMatch = type ? product.productType === type : true;
-    return typeMatch && !!product.featured;
-  });
-}
-
-/**
  * Get products by level
  * @param level The level to filter by
  * @param count Maximum number of products to return
@@ -108,17 +69,4 @@ export function getProductsByLevel(level: string, count?: number): Product[] {
   }
 
   return filteredByLevel;
-}
-
-/**
- * Get bestseller products
- * @param count Number of bestseller products to return
- * @returns Array of bestseller products
- */
-export function getBestsellerProducts(count: number): Product[] {
-  return getRandomProducts(
-    count,
-    (product) =>
-      Array.isArray(product.popularityTags) && product.popularityTags.includes('bestSeller')
-  );
 }


### PR DESCRIPTION
## Summary

Resolves #62.

### Artificial loading delays

All four catalog containers (general, books, packs, exams) wrapped their client-side filter/sort logic in a `setTimeout` of 600-1000ms with comments like *"Aumentamos el retraso para apreciar mejor el skeleton"* and *"Deliberate delay to show skeleton loader"* — filtering an already-in-memory array of ~15 products doesn't need 600ms, that time was purely spent staring at a skeleton for no reason. The same pattern existed a second time in each file's initial-page-load skeleton reveal (800-1000ms). Removed every artificial wrapper delay; **kept** the 300ms delays that correspond to an actual CSS opacity transition (skeleton fade-out) since removing those would cause a visual jump instead of a smooth fade — the distinction is a delay tied to real animation timing vs. one invented to fake perceived loading time.

Also removed leftover debug `console.log` calls in `CatalogContainer.astro` that were logging filter state on every keystroke (dropped lint warnings from 121 to 118).

### Non-deterministic featured content

`getRandomProducts()` in `listProducts.ts` shuffled with `Math.random()` (Fisher-Yates), and `getFeaturedProducts()`/`getBestsellerProducts()` both called it. All three turned out to be **dead code** — grepped every importer of `listProducts.ts` and none of them use these three functions. The only live featured-product selection path (`FeaturedCatalog.astro`) already filters by the explicit `featured` JSON field and never used `Math.random()` at all. Deleted the three dead functions rather than "fixing" code with no callers — the codebase-wide `Math.random()` usage is now down to one legitimate case (`generateOrderRequestId()` in `checkoutMessage.ts`, a runtime order-tracking token, unrelated to editorial content).

### Verification

Built the site **twice from the same commit** and diffed `dist/` (per the issue's own "Build repetido del mismo commit y comparación de HTML" requirement). The only byte-level difference across all 30 pages was a single countdown-timer timestamp in `PromoSection.astro` (`new Date() + N days`, intentional — it's a live "offer ends in" countdown, not editorial content selection). Every other byte, including full product ordering on every catalog/home/ofertas page, was identical between the two builds.

Also manually verified (dev server + Playwright) that the catalog grid still reveals correctly and instantly on load and that add-to-cart/filter interactions weren't broken by the delay removal.

## Note (not part of this PR's scope)

While manually testing, I noticed the search input on `/catalogo/libros` doesn't actually narrow visible results in some paths I tried — that's the exact kind of catalog-filtering-consistency problem issue #56 exists to fix, not something #62 touches. Flagging it here so it isn't lost, but didn't change any filtering *logic* in this PR, only the artificial delays wrapping it.

## Test plan

- [x] `bun run format:check` / `lint` / `check` / `build` — all clean
- [x] `bun run check:links` — unaffected, still 0 broken links
- [x] `bun run test:unit` — 84/84 pass (unaffected)
- [x] `bun run test:e2e` — 18/18 pass, run twice for stability (some parallel-load flakiness on unrelated tests in this sandbox, reproduced clean on rerun)
- [x] Built the same commit twice and diffed `dist/` — identical except one intentional, unrelated countdown timestamp
- [x] Manually verified via Playwright that the catalog grid reveals immediately (no more 600-1000ms wait) without breaking rendering
EOF
