### PR TITLE
docs(project): synchronize README, AGENTS and docs/ with the actual implementation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,23 +19,23 @@
 
 El sitio es **100% estático** (sin adapter SSR). Los datos de productos viven como JSON en el repo y se "freezan" en el HTML en build time. Esto da máxima velocidad de carga (no hay servidor que responda, solo CDN).
 
-**Migración planificada**: Decap CMS en `/admin` (Sprint 7) permitirá editar el JSON via UI web sin tocar código, commiteando al repo y triggereando rebuild automático de Vercel. **Gist descartado** (no actualiza el sitio sin rebuild, sin validación de schema, rate limits de la API).
+**Decap CMS** en `/admin` permite editar el JSON via UI web sin tocar código. El backend apunta a la rama `main` (ver `public/admin/config.yml`); como `main` requiere PR + status checks, los cambios desde el CMS pasan por el mismo flujo de PR que cualquier otro cambio. El merge dispara `deploy-vercel.yml` (GitHub Actions), no la integración nativa de Vercel con Git (deshabilitada a propósito para evitar despliegues duplicados). **Gist fue descartado** como alternativa (no actualiza el sitio sin rebuild, sin validación de schema, rate limits de la API).
 
 ## 2. Stack técnico
 
-| Componente      | Versión                                                                   | Notas                                                |
-| --------------- | ------------------------------------------------------------------------- | ---------------------------------------------------- |
-| Framework       | Astro 7.0.6                                                               | Sitio estático, sin adapter SSR                      |
-| UI islands      | @astrojs/react 6.0.1 + React 19                                           | Solo para componentes interactivos (filtro, carrito) |
-| CSS             | Tailwind v4 (vía @tailwindcss/vite)                                       | Config en `src/styles/global.css` con `@theme`       |
-| Package manager | bun 1.3.14                                                                | NO usar npm/yarn                                     |
-| Lenguaje        | TypeScript (strict)                                                       | `tsconfig.json` extiende `astro/tsconfigs/strict`    |
-| Formato         | Prettier + prettier-plugin-astro + prettier-plugin-tailwindcss            |                                                      |
-| Lint            | ESLint flat config + eslint-plugin-astro + eslint-plugin-react + jsx-a11y |                                                      |
-| Commits         | Conventional Commits sin emojis                                           | commitlint + husky validan                           |
-| Releases        | release-please (main=Latest, develop=Pre-release rc)                      |                                                      |
-| Deploy          | Vercel (main=prod, develop=preview)                                       | vía GitHub Actions                                   |
-| DevContainer    | ghcr.io/sandovaldavid/fluentreads-devcontainer                            | Node 22 + bun + Astro CLI                            |
+| Componente      | Versión                                                                    | Notas                                                |
+| --------------- | -------------------------------------------------------------------------- | ---------------------------------------------------- |
+| Framework       | Astro 7.0.6                                                                | Sitio estático, sin adapter SSR                      |
+| UI islands      | @astrojs/react 6.0.1 + React 19                                            | Solo para componentes interactivos (filtro, carrito) |
+| CSS             | Tailwind v4 (vía @tailwindcss/vite)                                        | Config en `src/styles/global.css` con `@theme`       |
+| Package manager | bun 1.3.14                                                                 | NO usar npm/yarn                                     |
+| Lenguaje        | TypeScript (strict)                                                        | `tsconfig.json` extiende `astro/tsconfigs/strict`    |
+| Formato         | Prettier + prettier-plugin-astro + prettier-plugin-tailwindcss             |                                                      |
+| Lint            | ESLint flat config + eslint-plugin-astro + eslint-plugin-react + jsx-a11y  |                                                      |
+| Commits         | Conventional Commits sin emojis                                            | commitlint + husky validan                           |
+| Releases        | release-please (solo `main`: GitHub Release + tag `vX.Y.Z` + CHANGELOG.md) |                                                      |
+| Deploy          | Vercel (main=prod, develop=preview)                                        | vía GitHub Actions                                   |
+| DevContainer    | ghcr.io/sandovaldavid/fluentreads-devcontainer                             | Node 22 + bun + Astro CLI                            |
 
 ## 3. Estructura del proyecto
 
@@ -45,7 +45,7 @@ El sitio es **100% estático** (sin adapter SSR). Los datos de productos viven c
 ├── .github/workflows/      # CI + devcontainer + deploy + release-please
 ├── .husky/                 # Git hooks (pre-commit, commit-msg)
 ├── .vscode/                # Settings, tasks, keybindings, launch
-├── docs/                   # Documentación de deuda técnica (12 archivos .md)
+├── docs/                   # Auditoría técnica histórica (12 archivos .md) — ver docs/README.md, no es backlog activo
 │   ├── README.md           # Índice
 │   ├── audit-summary.md    # Resumen ejecutivo de auditoría
 │   ├── astro-best-practices.md
@@ -62,7 +62,7 @@ El sitio es **100% estático** (sin adapter SSR). Los datos de productos viven c
 ├── src/
 │   ├── assets/             # Imágenes procesadas por Vite/Astro
 │   ├── components/         # Componentes Astro + React islands
-│   ├── config/             # Configuración centralizada (site.ts) [TODO B2]
+│   ├── config/             # Configuración centralizada (site.ts)
 │   ├── content.config.ts   # Schemas Zod de las astro:content collections
 │   ├── data/                # JSON consumido via getCollection() (books, packs, exams, etc.)
 │   ├── layouts/            # Layout.astro (SEO, meta tags, JSON-LD)
@@ -126,7 +126,7 @@ feat(catalog): add feature.           # punto final
 - **Sin `any` sin justificación**: regla `@typescript-eslint/no-explicit-any: warn`.
 - **Sin `innerHTML` con datos dinámicos**: regla `no-restricted-syntax` (XSS).
 - **Sin `target="_blank"` sin `rel="noopener noreferrer"`**: regla `react/jsx-no-target-blank`.
-- **Imports via aliases**: `@components/*`, `@layouts/*`, `@styles/*`, `@utils/*`, `@types/*`, `@assets/*`, `@config/*`, `@scripts/*` (configurado en `tsconfig.json`).
+- **Imports via aliases**: `@components/*`, `@layouts/*`, `@styles/*`, `@utils/*`, `@app-types/*`, `@data/*`, `@assets/*`, `@config/*`, `@scripts/*` (configurado en `tsconfig.json`). Nota: el alias de tipos es `@app-types/*`, no `@types/*` — TypeScript trata cualquier especificador `@types/*` como un paquete de declaraciones de DefinitelyTyped y no lo resuelve como alias normal.
 - **Componentes Astro**: siempre definir `interface Props` tipada, nunca usar `Astro.props` sin tipo.
 - **React islands**: `client:visible` por defecto (no `client:load` salvo críticos above-the-fold).
 - **Estilos**: scoped en componentes (`<style>`) o archivos en `src/styles/`. Sin `:global()` innecesario.
@@ -171,6 +171,12 @@ bun run format:check     # Prettier --check .
 bun run check            # astro check (TypeScript + .astro validation)
 bun run typecheck        # alias de check
 
+# Tests
+bun run test:unit        # bun:test sobre tests/unit
+bun run test:e2e         # Playwright sobre tests/e2e (requiere navegador instalado)
+bun run test             # alias de test:unit
+bun run check:links      # valida que los enlaces internos no rompan (scripts/check-internal-links.mjs)
+
 # Build
 bun run build            # astro check && astro build (con type-check)
 bun run build:force      # astro build sin type-check (emergencias)
@@ -183,18 +189,20 @@ bun run build:force      # astro build sin type-check (emergencias)
 **Antes de terminar cualquier tarea**, verifica:
 
 ```sh
-bun run lint && bun run check && bun run build
+bun run lint && bun run check && bun run build && bun run test:unit
 ```
+
+`test:e2e` no corre en CI como check bloqueante (solo `lint`/`check`/`build` lo son — ver sección 7), pero corrélo localmente si tocaste catálogo, carrito, checkout o formularios.
 
 ## 7. Branching y releases
 
 ### Ramas
 
-| Rama                                      | Propósito          | Merge method                      | Release                                    |
-| ----------------------------------------- | ------------------ | --------------------------------- | ------------------------------------------ |
-| `main`                                    | Producción estable | merge-commit o squash (no rebase) | GitHub Release "Latest" (vX.Y.Z)           |
-| `develop`                                 | Pre-release        | squash por convención             | GitHub Release "Pre-release" (vX.Y.Z-rc.N) |
-| `feat/*`, `fix/*`, `refactor/*`, `docs/*` | Feature branches   | squash a develop/main             | -                                          |
+| Rama                                      | Propósito          | Merge method                      | Release                          |
+| ----------------------------------------- | ------------------ | --------------------------------- | -------------------------------- |
+| `main`                                    | Producción estable | merge-commit o squash (no rebase) | GitHub Release "Latest" (vX.Y.Z) |
+| `develop`                                 | Preview / staging  | squash por convención             | Ninguno — solo Vercel Preview    |
+| `feat/*`, `fix/*`, `refactor/*`, `docs/*` | Feature branches   | squash a develop/main             | -                                |
 
 ### Reglas (via GitHub Rulesets)
 
@@ -208,25 +216,32 @@ bun run lint && bun run check && bun run build
 
 ### release-please
 
-- Push a `main` → `release-please-main.yml` crea PR de release → merge → GitHub Release "Latest" + tag `vX.Y.Z` + CHANGELOG.md.
-- Push a `develop` → `release-please-develop.yml` crea PR de pre-release → merge → GitHub Release "Pre-release" + tag `vX.Y.Z-rc.N`.
-- **El histórico anterior usa gitmojis**: release-please los agrupará en el primer release `v0.1.0` como "Initial release". A partir de ahí, solo commits convencionales.
+- `release-please.yml` corre **únicamente en push a `main`** (`target-branch: main`) — no existe un workflow equivalente para `develop`. Crea un PR de release → al mergear, publica un GitHub Release "Latest" + tag `vX.Y.Z` + CHANGELOG.md.
+- `develop` no genera releases ni tags; solo dispara `deploy-vercel.yml` para el Preview.
+- **El histórico anterior usa gitmojis**: release-please los agrupó en el primer release `v0.1.0` como "Initial release". A partir de ahí, solo commits convencionales.
+
+### Deploy
+
+- `deploy-vercel.yml` corre en push a `main` y `develop`. Construye el sitio y despliega vía Vercel CLI (`vercel deploy`) usando los secrets `VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID`.
+- La integración nativa de Vercel con Git está **deshabilitada a propósito** — si estuviera activa, cada push desplegaría dos veces (una vez por la integración nativa, otra por el workflow).
+- Sin esos tres secrets configurados en el repo, el job falla rápido (timeout de 10 min) en lugar de colgarse — ver issue [#63](https://github.com/sandovaldavid/fluentreads/issues/63) si siguen sin configurarse.
 
 ## 8. Enfoque de base de datos
 
-### Actual (post-B8)
+### Estado actual
 
-`astro:content` collections definidas en `src/content.config.ts`, con loader `file()` y schemas Zod para cada colección (books, packs, exams, testimonies, offers, editorial, categories, faqs, pageInformation, etc.). Los datos viven como JSON en `src/data/` y se consumen via `getCollection('nombre')` — **nunca** imports directos de JSON. Los schemas Zod validan en build time (enums, tipos, campos requeridos).
+`astro:content` collections definidas en `src/content.config.ts`, con loader `file()` y schemas Zod para cada colección (books, packs, exams, testimonies, offers, editorial, categories, faqs, legal, etc.). Los datos viven como JSON en `src/data/` y se consumen via `getCollection('nombre')` — **nunca** imports directos de JSON para colecciones registradas (confirmado: cero imports directos de `src/data/*.json` en `src/` para archivos que tienen un schema Zod). Los schemas Zod validan en build time (enums, tipos, campos requeridos). Excepción intencional: `page-information.json` no es una content collection (no tiene schema Zod) y se sigue importando directamente.
 
-### Edición sin código (Sprint 7)
+### Edición sin código
 
-**Decap CMS** en `/admin`:
+**Decap CMS** en `/admin` — implementado y en uso:
 
-- Panel web para editar JSON via UI.
+- Panel web para editar JSON via UI, configurado en `public/admin/config.yml` + `public/admin/index.html`.
 - Auth via GitHub OAuth.
-- Commit al repo → Vercel rebuild automático via Git integration.
+- Backend apunta a la rama `main`. Como `main` exige PR + status checks (`lint`/`check`/`build`), los commits del CMS no van directo a producción — pasan por el mismo flujo de PR y CI que cualquier otro cambio.
+- El merge a `main` dispara `deploy-vercel.yml`, no la integración nativa de Vercel con Git.
 - Mantiene content collections + validación Zod.
-- **Gist descartado**: no actualiza el sitio sin rebuild, sin validación, rate limits.
+- **Gist fue descartado**: no actualiza el sitio sin rebuild, sin validación, rate limits.
 
 ## 9. Anti-patterns (LO QUE NO DEBES HACER)
 
@@ -249,33 +264,27 @@ bun run lint && bun run check && bun run build
 
 ## 10. Antes de empezar una tarea
 
-1. **Lee `docs/roadmap.md`** para ver en qué sprint/bloque estás.
-2. **Lee el doc específico del bloque** (e.g. `docs/bugs-logic.md` para B3, `docs/astro-best-practices.md` para B0/B8).
-3. **Consulta `docs/audit-summary.md`** para contexto general de la deuda técnica.
-4. **Verifica el MCP de Astro** para APIs que vayas a usar (especialmente si tocas `astro.config.mjs`, content collections, imágenes, view transitions).
-5. **Termina con**: `bun run lint && bun run check && bun run build` pasando limpio.
+1. **Revisa la issue de seguimiento [#65](https://github.com/sandovaldavid/fluentreads/issues/65)** para ver qué queda pendiente y en qué orden — es la fuente de verdad vigente, no `docs/roadmap.md`.
+2. **Si tu tarea toca algo ya cubierto por una issue cerrada**, verifica el estado actual en el código, no en `docs/` — esos documentos son un archivo histórico de la auditoría original (ver `docs/README.md`).
+3. **Verifica el MCP de Astro** para APIs que vayas a usar (especialmente si tocas `astro.config.mjs`, content collections, imágenes, view transitions).
+4. **Termina con**: `bun run lint && bun run check && bun run build` pasando limpio.
 
-## 11. Estado actual de la deuda técnica
+## 11. Estado actual del proyecto
 
-Ver `docs/README.md` para el estado de cada bloque. Resumen:
+La fuente de verdad es GitHub, no este archivo ni `docs/`. Issue de seguimiento: [#65](https://github.com/sandovaldavid/fluentreads/issues/65) (fases 1-5 de estabilización).
 
-- **B0 (tooling)**: completado en este commit.
-- **B1 (CI/CD)**: pendiente — deploy Vercel + release-please.
-- **B2 (centralización)**: pendiente — `src/config/site.ts`.
-- **B3 (bugs lógica)**: pendiente — 30 bugs P0-P2.
-- **B4 (bugs estilos)**: pendiente — 18 bugs.
-- **B5 (accesibilidad)**: pendiente — 19 issues.
-- **B6 (performance)**: pendiente — 16 issues.
-- **B7 (seguridad)**: pendiente — 13 issues.
-- **B8 (refactor collections)**: pendiente — Sprint 5-6.
-- **B9 (features incompletas)**: pendiente — Sprint 6-7 (incluye Decap CMS).
-- **B10 (README + docs finales)**: pendiente — Sprint 8.
+Al momento de escribir esto:
+
+- **Cerradas**: #50 (quality gates), #51 (tests), #52 (Decap CMS), #54 (checkout), #55 (service worker), #56 (filtros de catálogo), #57 (content collections), #58 (SEO), #59 (rutas), #60 (seguridad), #61 (formularios), #62 (latencia artificial), #64 (esta sincronización de docs).
+- **Abiertas**: #53 (reemplazar catálogo demo por datos reales — requiere información de negocio que no está disponible, no se debe inventar), #63 (gobernanza de deploy — el workflow y el ruleset ya están correctos, pero falta que se configuren los secrets `VERCEL_TOKEN`/`VERCEL_ORG_ID`/`VERCEL_PROJECT_ID` en el repo).
+
+Antes de asumir que algo "está pendiente", confirma en `gh issue list` o en el código — `docs/` puede estar desactualizado por diseño (ver nota en `docs/README.md`).
 
 ## 12. Referencias
 
 - [Documentación de Astro](https://docs.astro.build) (via MCP astro-docs)
-- [docs/](./docs/) — auditoría técnica completa
-- [docs/roadmap.md](./docs/roadmap.md) — cronograma de sprints
+- [Issue #65](https://github.com/sandovaldavid/fluentreads/issues/65) — estado vigente de la estabilización del proyecto
+- [docs/](./docs/) — auditoría técnica histórica (pre-estabilización), no backlog activo
 - [Conventional Commits](https://www.conventionalcommits.org/) — formato de commits
-- [release-please](https://github.com/googleapis/release-please) — automatización de releases
-- [Decap CMS](https://decapcms.org/) — CMS para sitios estáticos (planificado Sprint 7)
+- [release-please](https://github.com/googleapis/release-please) — automatización de releases (solo `main`)
+- [Decap CMS](https://decapcms.org/) — CMS para sitios estáticos, ya implementado en `/admin`

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ FluentReads is a high-performance, 100% static e-commerce platform designed for 
 - **Dynamic Static Catalog**: Products are defined as JSON content collections and baked directly into HTML at build time, yielding near-instant page loads.
 - **Client-Side Cart**: Managed entirely via `CartManager.ts`, synchronizing state in `localStorage` and dispatching custom reactive events.
 - **WhatsApp Checkout**: Generates checkout summaries and transfers order details directly to the seller via WhatsApp.
-- **Decap CMS Support**: Administrators can manage and edit the catalog using a web UI at `/admin`. Changes are saved back to GitHub, triggering an automatic Vercel build.
+- **Decap CMS Support**: Administrators can manage and edit the catalog using a web UI at `/admin`. The CMS backend targets `main`, which requires a PR with passing `lint`/`check`/`build` checks — content edits go through the same review gate as code. Merging triggers the `deploy-vercel.yml` GitHub Actions workflow (Vercel's native Git integration is intentionally disabled to avoid double-deploying the same commit).
 - **Service Worker Integration**: Integrates a custom service worker (`public/sw.js`) supporting stale-while-revalidate and offline-first cache strategies for resources.
 
 ## Architecture and Structure
@@ -32,8 +32,11 @@ The codebase is organized as follows:
 │   ├── scripts/            # Client-side scripts and interaction logic
 │   ├── styles/             # Global styling (Tailwind CSS v4)
 │   ├── types/              # Strict TypeScript type declarations
-│   └── utils/              # Helper utilities (CartManager, filtering)
-├── docs/                   # Roadmaps, technical audits, and sprint documentation
+│   └── utils/              # Helper utilities (CartManager, catalogFilters, etc.)
+├── tests/
+│   ├── unit/                # bun:test suites
+│   └── e2e/                 # Playwright suites (catalog, checkout, forms, a11y, SEO, etc.)
+├── docs/                   # Historical technical audit (see docs/README.md) — not an active backlog
 └── package.json            # Scripts, dependencies, and configuration
 ```
 
@@ -103,18 +106,22 @@ bun run preview
 
 The following helper scripts are configured in `package.json`:
 
-| Script         | Command                        | Purpose                                          |
-| :------------- | :----------------------------- | :----------------------------------------------- |
-| `dev`          | `astro dev`                    | Run the local dev server                         |
-| `build`        | `bun run check && astro build` | Verify and bundle static files                   |
-| `build:force`  | `astro build`                  | Build without verification checks                |
-| `preview`      | `astro preview`                | Serve the production build locally               |
-| `check`        | `astro check`                  | Run Astro validation and TypeScript verification |
-| `typecheck`    | `bun run check`                | Run type checking across the project             |
-| `lint`         | `eslint .`                     | Verify codebase styles with ESLint               |
-| `lint:fix`     | `eslint . --fix`               | Automatically fix linting violations             |
-| `format`       | `prettier --write .`           | Format files according to Prettier settings      |
-| `format:check` | `prettier --check .`           | Check files formatting without writing           |
+| Script         | Command                                 | Purpose                                                   |
+| :------------- | :-------------------------------------- | :-------------------------------------------------------- |
+| `dev`          | `astro dev`                             | Run the local dev server                                  |
+| `build`        | `bun run check && astro build`          | Verify and bundle static files                            |
+| `build:force`  | `astro build`                           | Build without verification checks                         |
+| `preview`      | `astro preview`                         | Serve the production build locally                        |
+| `check`        | `astro check`                           | Run Astro validation and TypeScript verification          |
+| `typecheck`    | `bun run check`                         | Run type checking across the project                      |
+| `lint`         | `eslint .`                              | Verify codebase styles with ESLint                        |
+| `lint:fix`     | `eslint . --fix`                        | Automatically fix linting violations                      |
+| `format`       | `prettier --write .`                    | Format files according to Prettier settings               |
+| `format:check` | `prettier --check .`                    | Check files formatting without writing                    |
+| `test:unit`    | `bun test tests/unit`                   | Run the `bun:test` unit suite                             |
+| `test:e2e`     | `playwright test`                       | Run the Playwright E2E suite (requires a browser install) |
+| `test`         | alias of `test:unit`                    | Run unit tests                                            |
+| `check:links`  | `node scripts/check-internal-links.mjs` | Verify internal links in the built site don't 404         |
 
 ## Content Collections
 
@@ -146,7 +153,7 @@ window.CMS.registerFormat('json-array', 'json', {
 });
 ```
 
-Modifying content in the `/admin` portal commits files directly to GitHub, triggering a rebuild on Vercel automatically.
+Modifying content in the `/admin` portal opens a PR against `main` (auth via GitHub OAuth). Once the PR's CI checks pass and it merges, `deploy-vercel.yml` builds and deploys via the Vercel CLI — not Vercel's native Git integration, which is disabled to prevent a single commit from triggering two separate deployments.
 
 ## Environment Variables
 
@@ -165,5 +172,11 @@ We enforce conventional commit messages. All pull requests and commits must foll
 type(scope): description in imperative
 ```
 
-- **Branching Policy**: Merges to the `develop` branch generate Vercel preview environments. Merges to `main` update the production site and trigger `release-please` to auto-bump version numbers and generate changelogs.
-- **Git Hooks**: Pre-commit hooks run ESLint and Prettier check formatting before code is allowed to commit.
+- **Branching Policy**: Merges to `develop` deploy a Vercel Preview environment (no release is cut). Merges to `main` deploy production and trigger `release-please` — which runs only on `main` — to open a release PR that, once merged, auto-bumps the version, publishes a GitHub Release, and updates `CHANGELOG.md`.
+- **Required checks**: `main` and `develop` both require a PR with passing `lint`/`check`/`build` status checks before merge (force-push and branch deletion are blocked on both).
+- **Git Hooks**: Pre-commit hooks run ESLint and Prettier check formatting before code is allowed to commit; commit-msg hooks validate Conventional Commits formatting.
+
+## Known Gaps
+
+- **Deploy secrets**: `deploy-vercel.yml` requires `VERCEL_TOKEN`, `VERCEL_ORG_ID`, and `VERCEL_PROJECT_ID` configured as repository secrets. Without them the deploy job fails fast rather than publishing — see [issue #63](https://github.com/sandovaldavid/fluentreads/issues/63).
+- **Catalog data**: the current `src/data/*.json` catalog content is demo/placeholder data, not verified real business data — see [issue #53](https://github.com/sandovaldavid/fluentreads/issues/53).

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,42 +1,47 @@
 # FluentReads - Documentacion de deuda tecnica
 
-Indice de la auditoria tecnica completa del proyecto FluentReads (Astro 7 + React 19 + Tailwind v4 + bun).
+> [!NOTE]
+> **Este directorio es un archivo histórico.** Contiene la auditoría técnica original del proyecto (pre-estabilización) que sirvió de base para las issues [#50](https://github.com/sandovaldavid/fluentreads/issues/50) a [#65](https://github.com/sandovaldavid/fluentreads/issues/65). Casi todos los hallazgos aquí listados ya fueron resueltos. **Para el estado vigente de la deuda técnica, usa el tracker [#65](https://github.com/sandovaldavid/fluentreads/issues/65)** (y los issues individuales que enlaza), no las tablas de este README ni los `status:` en el frontmatter de cada documento — quedaron congelados en el momento de la auditoría y no se actualizan.
 
-## Estado de los bloques
+## Estado vigente (fuente de verdad: issues de GitHub)
 
-| Bloque | Documento                                    | Estado | Sprint |
-| ------ | -------------------------------------------- | ------ | ------ |
-| B0     | Tooling de calidad + CI base                 | done   | S1     |
-| B1     | CI/CD: Vercel deploy + release-please        | done   | S1     |
-| B2     | Centralizacion de variables mudables         | done   | S2     |
-| B3     | Bugs criticos de logica y sintaxis           | done   | S2     |
-| B4     | Bugs de estilos                              | done   | S3     |
-| B5     | Accesibilidad                                | done   | S3     |
-| B6     | Performance                                  | done   | S4     |
-| B7     | Seguridad                                    | done   | S4     |
-| B8     | Refactor arquitectonico: content collections | done   | S5-S6  |
-| B9     | Features incompletas                         | done   | S6-S7  |
-| B10    | README + docs finales                        | done   | S8     |
+| Issue                                                         | Tema                                                 | Estado                                                            |
+| ------------------------------------------------------------- | ---------------------------------------------------- | ----------------------------------------------------------------- |
+| [#65](https://github.com/sandovaldavid/fluentreads/issues/65) | Tracker de estabilización (fases 1-5)                | Abierto — resume el estado de todo lo demás                       |
+| [#50](https://github.com/sandovaldavid/fluentreads/issues/50) | Quality gates estrictos (astro check, CI)            | Cerrado                                                           |
+| [#51](https://github.com/sandovaldavid/fluentreads/issues/51) | Cobertura de pruebas (unit + e2e + a11y)             | Cerrado                                                           |
+| [#63](https://github.com/sandovaldavid/fluentreads/issues/63) | Gobernanza de `develop`/`main`, releases y deploy    | Abierto — pendiente que se configuren los secrets de Vercel       |
+| [#52](https://github.com/sandovaldavid/fluentreads/issues/52) | Decap CMS alineado con el flujo real de publicación  | Cerrado                                                           |
+| [#53](https://github.com/sandovaldavid/fluentreads/issues/53) | Reemplazar catálogo demo por datos verificados       | Abierto — requiere datos de negocio reales, no se pueden inventar |
+| [#61](https://github.com/sandovaldavid/fluentreads/issues/61) | Formularios de contacto/newsletter confiables        | Cerrado                                                           |
+| [#60](https://github.com/sandovaldavid/fluentreads/issues/60) | Headers de seguridad y scripts de terceros           | Cerrado                                                           |
+| [#54](https://github.com/sandovaldavid/fluentreads/issues/54) | Totales de WhatsApp checkout confiables              | Cerrado                                                           |
+| [#55](https://github.com/sandovaldavid/fluentreads/issues/55) | Service worker sin precios obsoletos                 | Cerrado                                                           |
+| [#59](https://github.com/sandovaldavid/fluentreads/issues/59) | Rutas de categorías del catálogo                     | Cerrado                                                           |
+| [#58](https://github.com/sandovaldavid/fluentreads/issues/58) | Metadata social y datos estructurados                | Cerrado                                                           |
+| [#57](https://github.com/sandovaldavid/fluentreads/issues/57) | Content Collections como fuente única de verdad      | Cerrado                                                           |
+| [#56](https://github.com/sandovaldavid/fluentreads/issues/56) | Unificación de filtros/orden/URL del catálogo        | Cerrado                                                           |
+| [#62](https://github.com/sandovaldavid/fluentreads/issues/62) | Latencia artificial y contenido destacado            | Cerrado                                                           |
+| [#64](https://github.com/sandovaldavid/fluentreads/issues/64) | Sincronizar esta documentación con la implementación | En curso (este cambio)                                            |
 
-## Indice de documentos
+## Indice de documentos historicos
 
-| Documento                                            | Descripcion                               |
-| ---------------------------------------------------- | ----------------------------------------- |
-| [audit-summary.md](./audit-summary.md)               | Resumen ejecutivo de la auditoria         |
-| [astro-best-practices.md](./astro-best-practices.md) | Violaciones de mejores practicas de Astro |
-| [bugs-logic.md](./bugs-logic.md)                     | Bugs de logica y sintaxis                 |
-| [bugs-styles.md](./bugs-styles.md)                   | Bugs de CSS y estilos                     |
-| [accessibility.md](./accessibility.md)               | Issues de accesibilidad                   |
-| [performance.md](./performance.md)                   | Issues de rendimiento                     |
-| [security.md](./security.md)                         | Issues de seguridad                       |
-| [duplicate-dead-code.md](./duplicate-dead-code.md)   | Codigo duplicado y muerto                 |
-| [incomplete-features.md](./incomplete-features.md)   | Features incompletas o a medio hacer      |
-| [database-schema.md](./database-schema.md)           | Inconsistencias de schema en JSON         |
-| [roadmap.md](./roadmap.md)                           | Cronograma de sprints quincenales         |
+| Documento                                            | Descripcion                                                                                                                                 |
+| ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| [audit-summary.md](./audit-summary.md)               | Resumen ejecutivo de la auditoria original                                                                                                  |
+| [astro-best-practices.md](./astro-best-practices.md) | Violaciones de mejores practicas de Astro (halladas antes de la estabilización)                                                             |
+| [bugs-logic.md](./bugs-logic.md)                     | Bugs de logica y sintaxis hallados en la auditoria                                                                                          |
+| [bugs-styles.md](./bugs-styles.md)                   | Bugs de CSS y estilos hallados en la auditoria                                                                                              |
+| [accessibility.md](./accessibility.md)               | Issues de accesibilidad hallados en la auditoria                                                                                            |
+| [performance.md](./performance.md)                   | Issues de rendimiento hallados en la auditoria                                                                                              |
+| [security.md](./security.md)                         | Issues de seguridad hallados en la auditoria                                                                                                |
+| [duplicate-dead-code.md](./duplicate-dead-code.md)   | Codigo duplicado y muerto hallado en la auditoria                                                                                           |
+| [incomplete-features.md](./incomplete-features.md)   | Features incompletas halladas en la auditoria                                                                                               |
+| [database-schema.md](./database-schema.md)           | Inconsistencias de schema en JSON halladas en la auditoria (los schemas Zod en `src/content.config.ts` las validan en build time desde #57) |
+| [roadmap.md](./roadmap.md)                           | Cronograma de sprints quincenales original                                                                                                  |
 
-## Convenciones
+## Convenciones (aplican solo dentro de cada documento historico)
 
-- Cada issue referencia `archivo:linea` para navegacion directa.
-- `status: pending` = no empezado, `in-progress` = en curso, `done` = completado.
-- `priority: P0` = critico (rompe funcionalidad), `P1` = alto, `P2` = medio, `P3` = bajo.
-- Los bloques B0-B10 se ejecutan como PRs separados con commits convencionales sin emojis.
+- Cada issue referenciado en estos documentos usa el formato `archivo:linea` para navegacion directa — puede haber quedado desactualizado si el archivo se movio o reescribio desde entonces.
+- `priority: P0` = critico, `P1` = alto, `P2` = medio, `P3` = bajo (vigente solo como contexto historico de la severidad original).
+- El campo `status:` de cada documento es `historical` — no representa si el trabajo esta hecho o no; para eso usa la tabla de issues de arriba.

--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -1,8 +1,11 @@
 ---
-status: done
+status: historical
 block: B5
 priority: P1
 ---
+
+> [!NOTE]
+> **Documento histórico.** Esta es una fotografía de la auditoría técnica original (previa a la estabilización del proyecto). Los hallazgos aquí descritos ya fueron total o parcialmente resueltos a través de las issues [#50](https://github.com/sandovaldavid/fluentreads/issues/50)-[#65](https://github.com/sandovaldavid/fluentreads/issues/65). Para el estado vigente de la deuda técnica, consulta la issue de seguimiento [#65](https://github.com/sandovaldavid/fluentreads/issues/65), no este documento. No uses este archivo como backlog activo.
 
 # Issues de accesibilidad
 

--- a/docs/astro-best-practices.md
+++ b/docs/astro-best-practices.md
@@ -1,8 +1,11 @@
 ---
-status: pending
+status: historical
 block: B0, B8
 priority: P0
 ---
+
+> [!NOTE]
+> **Documento histórico.** Esta es una fotografía de la auditoría técnica original (previa a la estabilización del proyecto). Los hallazgos aquí descritos ya fueron total o parcialmente resueltos a través de las issues [#50](https://github.com/sandovaldavid/fluentreads/issues/50)-[#65](https://github.com/sandovaldavid/fluentreads/issues/65). Para el estado vigente de la deuda técnica, consulta la issue de seguimiento [#65](https://github.com/sandovaldavid/fluentreads/issues/65), no este documento. No uses este archivo como backlog activo.
 
 # Violaciones de mejores practicas de Astro
 

--- a/docs/audit-summary.md
+++ b/docs/audit-summary.md
@@ -1,8 +1,11 @@
 ---
-status: pending
+status: historical
 block: all
 priority: P0
 ---
+
+> [!NOTE]
+> **Documento histórico.** Esta es una fotografía de la auditoría técnica original (previa a la estabilización del proyecto). Los hallazgos aquí descritos ya fueron total o parcialmente resueltos a través de las issues [#50](https://github.com/sandovaldavid/fluentreads/issues/50)-[#65](https://github.com/sandovaldavid/fluentreads/issues/65). Para el estado vigente de la deuda técnica, consulta la issue de seguimiento [#65](https://github.com/sandovaldavid/fluentreads/issues/65), no este documento. No uses este archivo como backlog activo.
 
 # Resumen ejecutivo de la auditoria
 

--- a/docs/bugs-logic.md
+++ b/docs/bugs-logic.md
@@ -1,8 +1,11 @@
 ---
-status: pending
+status: historical
 block: B3
 priority: P0
 ---
+
+> [!NOTE]
+> **Documento histórico.** Esta es una fotografía de la auditoría técnica original (previa a la estabilización del proyecto). Los hallazgos aquí descritos ya fueron total o parcialmente resueltos a través de las issues [#50](https://github.com/sandovaldavid/fluentreads/issues/50)-[#65](https://github.com/sandovaldavid/fluentreads/issues/65). Para el estado vigente de la deuda técnica, consulta la issue de seguimiento [#65](https://github.com/sandovaldavid/fluentreads/issues/65), no este documento. No uses este archivo como backlog activo.
 
 # Bugs de logica y sintaxis
 

--- a/docs/bugs-styles.md
+++ b/docs/bugs-styles.md
@@ -1,8 +1,11 @@
 ---
-status: done
+status: historical
 block: B4
 priority: P1
 ---
+
+> [!NOTE]
+> **Documento histórico.** Esta es una fotografía de la auditoría técnica original (previa a la estabilización del proyecto). Los hallazgos aquí descritos ya fueron total o parcialmente resueltos a través de las issues [#50](https://github.com/sandovaldavid/fluentreads/issues/50)-[#65](https://github.com/sandovaldavid/fluentreads/issues/65). Para el estado vigente de la deuda técnica, consulta la issue de seguimiento [#65](https://github.com/sandovaldavid/fluentreads/issues/65), no este documento. No uses este archivo como backlog activo.
 
 # Bugs de estilos
 

--- a/docs/database-schema.md
+++ b/docs/database-schema.md
@@ -1,8 +1,11 @@
 ---
-status: done
+status: historical
 block: B8
 priority: P0
 ---
+
+> [!NOTE]
+> **Documento histórico.** Esta es una fotografía de la auditoría técnica original (previa a la estabilización del proyecto). Los hallazgos aquí descritos ya fueron total o parcialmente resueltos a través de las issues [#50](https://github.com/sandovaldavid/fluentreads/issues/50)-[#65](https://github.com/sandovaldavid/fluentreads/issues/65). Para el estado vigente de la deuda técnica, consulta la issue de seguimiento [#65](https://github.com/sandovaldavid/fluentreads/issues/65), no este documento. No uses este archivo como backlog activo.
 
 # Inconsistencias de schema en base de datos JSON
 

--- a/docs/duplicate-dead-code.md
+++ b/docs/duplicate-dead-code.md
@@ -1,8 +1,11 @@
 ---
-status: pending
+status: historical
 block: B3, B8
 priority: P1
 ---
+
+> [!NOTE]
+> **Documento histórico.** Esta es una fotografía de la auditoría técnica original (previa a la estabilización del proyecto). Los hallazgos aquí descritos ya fueron total o parcialmente resueltos a través de las issues [#50](https://github.com/sandovaldavid/fluentreads/issues/50)-[#65](https://github.com/sandovaldavid/fluentreads/issues/65). Para el estado vigente de la deuda técnica, consulta la issue de seguimiento [#65](https://github.com/sandovaldavid/fluentreads/issues/65), no este documento. No uses este archivo como backlog activo.
 
 # Codigo duplicado y muerto
 

--- a/docs/incomplete-features.md
+++ b/docs/incomplete-features.md
@@ -1,8 +1,11 @@
 ---
-status: done
+status: historical
 block: B9
 priority: P2
 ---
+
+> [!NOTE]
+> **Documento histórico.** Esta es una fotografía de la auditoría técnica original (previa a la estabilización del proyecto). Los hallazgos aquí descritos ya fueron total o parcialmente resueltos a través de las issues [#50](https://github.com/sandovaldavid/fluentreads/issues/50)-[#65](https://github.com/sandovaldavid/fluentreads/issues/65). Para el estado vigente de la deuda técnica, consulta la issue de seguimiento [#65](https://github.com/sandovaldavid/fluentreads/issues/65), no este documento. No uses este archivo como backlog activo.
 
 # Features incompletas
 
@@ -156,9 +159,9 @@ Lista de features a medio hacer, rutas rotas y placeholders, con referencias `ar
 **Estado**: Completado (`done`).
 **Solucion**:
 
-- Instalado y configurado `decap-cms-app` en [public/admin/index.html](file:///home/sandovaldavid/workspaces/me/projects/fluentreads/public/admin/index.html) y [public/admin/config.yml](file:///home/sandovaldavid/workspaces/me/projects/fluentreads/public/admin/config.yml).
+- Instalado y configurado `decap-cms-app` en [public/admin/index.html](../public/admin/index.html) y [public/admin/config.yml](../public/admin/config.yml).
 - Implementado proxy de desarrollo local en puerto `8081` (`decap-server`).
-- Creadas **previsualizaciones personalizadas en tiempo real de alta fidelidad** en React + CSS personalizado [public/admin/preview.css](file:///home/sandovaldavid/workspaces/me/projects/fluentreads/public/admin/preview.css) para todas las colecciones (Libros, Packs, Exámenes, Editoriales, Categorías, Testimonios, Ofertas Especiales, FAQs y Banner Hero de Ofertas).
+- Creadas **previsualizaciones personalizadas en tiempo real de alta fidelidad** en React + CSS personalizado [public/admin/preview.css](../public/admin/preview.css) para todas las colecciones (Libros, Packs, Exámenes, Editoriales, Categorías, Testimonios, Ofertas Especiales, FAQs y Banner Hero de Ofertas).
 - Añadido motor de **autogeneración de metadatos** (IDs, detalles y enlaces de compra automáticos al escribir el título de un ítem) con sincronización de estado en React.
 - Configurado widget `select` estático para la asignación de editoriales de forma consistente y robusta.
 - Implementadas **validaciones de rangos numéricos** (`min`/`max`) en todas las colecciones para puntajes, precios, descuentos y contadores.

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1,8 +1,11 @@
 ---
-status: done
+status: historical
 block: B6
 priority: P1
 ---
+
+> [!NOTE]
+> **Documento histórico.** Esta es una fotografía de la auditoría técnica original (previa a la estabilización del proyecto). Los hallazgos aquí descritos ya fueron total o parcialmente resueltos a través de las issues [#50](https://github.com/sandovaldavid/fluentreads/issues/50)-[#65](https://github.com/sandovaldavid/fluentreads/issues/65). Para el estado vigente de la deuda técnica, consulta la issue de seguimiento [#65](https://github.com/sandovaldavid/fluentreads/issues/65), no este documento. No uses este archivo como backlog activo.
 
 # Issues de rendimiento
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,8 +1,11 @@
 ---
-status: done
+status: historical
 block: all
 priority: P0
 ---
+
+> [!NOTE]
+> **Documento histórico.** Este cronograma de sprints fue el plan original de estabilización. El trabajo real se ejecutó y se sigue rastreando a través de las issues [#50](https://github.com/sandovaldavid/fluentreads/issues/50)-[#65](https://github.com/sandovaldavid/fluentreads/issues/65), no en sprints quincenales. Para el estado vigente, consulta la issue de seguimiento [#65](https://github.com/sandovaldavid/fluentreads/issues/65).
 
 # Cronograma de sprints quincenales
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,8 +1,11 @@
 ---
-status: done
+status: historical
 block: B7
 priority: P0
 ---
+
+> [!NOTE]
+> **Documento histórico.** Esta es una fotografía de la auditoría técnica original (previa a la estabilización del proyecto). Los hallazgos aquí descritos ya fueron total o parcialmente resueltos a través de las issues [#50](https://github.com/sandovaldavid/fluentreads/issues/50)-[#65](https://github.com/sandovaldavid/fluentreads/issues/65). Para el estado vigente de la deuda técnica, consulta la issue de seguimiento [#65](https://github.com/sandovaldavid/fluentreads/issues/65), no este documento. No uses este archivo como backlog activo.
 
 # Issues de seguridad
 


### PR DESCRIPTION
## Summary

Closes #64. Audited README.md, AGENTS.md, CONTRIBUTING.md and every file in `docs/` against the actual code, workflows, and config — cross-referenced with the closed/open state of issues #50-#65.

### The core problem this fixes

`docs/README.md` claimed every audit block (B0-B10) was `done`, while each individual doc kept its own `status: pending` (or `done`) frontmatter that was never updated — directly contradictory within the same directory. Separately, `AGENTS.md` described:
- Decap CMS as "planned for Sprint 7" — it's been live at `/admin` since #52.
- `release-please` running on both `main` and `develop` — it only ever targets `main` (confirmed against `.github/workflows/release-please.yml`, no `release-please-develop.yml` exists).
- The `@types/*` import alias — renamed to `@app-types/*` in #56, because TypeScript reserves any `@types/*` specifier for DefinitelyTyped-style declaration packages and refuses to resolve it as a normal alias. The old reference would have actively misled anyone who tried to use it.
- `src/config/` still tagged `[TODO B2]` even though it's been in active use throughout this whole session.
- A "estado de la deuda técnica" section listing almost everything as pending despite #50-#62 having closed it out.

### What changed

- **`docs/README.md`** and all 11 audit-topic docs (`bugs-logic`, `bugs-styles`, `accessibility`, `performance`, `security`, `duplicate-dead-code`, `incomplete-features`, `database-schema`, `astro-best-practices`, `audit-summary`, `roadmap`) now carry a clear historical banner + normalized `status: historical` frontmatter, replacing the inconsistent pending/done mix. **Content is untouched** — this preserves the historical audit record rather than deleting context, per the issue's own risk warning.
- GitHub issues #50-#65 (specifically the stabilization tracker [#65](https://github.com/sandovaldavid/fluentreads/issues/65)) are now the documented single source of truth for current status — per the issue's solution point 5 ("representar deuda vigente mediante issues, no mediante checklists históricas ambiguas").
- **`AGENTS.md`**: Decap description fixed to present-tense/implemented, release-please description fixed to main-only, `@types/*` → `@app-types/*` (+ noted why), removed the stale `[TODO B2]` tag, added the missing `test:unit`/`test:e2e`/`check:links` commands, replaced the B0-B10 status table with a pointer to issue #65 and a snapshot of what's actually open (#53, #63) vs. closed.
- **`README.md`**: fixed the Decap deploy-trigger description to match the real `deploy-vercel.yml` GitHub Actions flow (Vercel's native Git integration is intentionally disabled to avoid double-deploys), added the missing `tests/` directory to the architecture tree and the missing scripts to the table, fixed the release-please branching claim, added a "Known Gaps" section linking the two issues that are still genuinely open (#53 demo data, #63 missing deploy secrets).
- Fixed three links in `docs/incomplete-features.md` that used absolute `file:///home/...` paths (not portable) — now relative repo paths.
- Checked off the completed phases/items in issue #65's tracker checklist to match reality.
- `CONTRIBUTING.md` was already accurate (updated during #63) — verified, left as is.

## Deferred / out of scope

- Issues #53 (demo catalog data) and #63 (missing Vercel deploy secrets) remain genuinely open — documented as such rather than glossed over, since closing them requires real business data or repo-secret access I don't have.
- No automated "docs describe reality" CI check was added (the issue's solution point 7, "cuando sea razonable") — the existing `check:links` script already catches broken internal links; a deeper doc-accuracy linter felt like scope creep for a documentation-sync pass.

## Test plan

Docs-only change, but ran the full local validation anyway since it touches scripts referenced in the docs themselves:
- [x] `bun run format:check` — clean
- [x] `bun run lint` — 0 errors (pre-existing warnings only)
- [x] `bun run check` — 0 errors
- [x] `bun run test:unit` — 88/88
- [x] `bun run build` — 30 pages
- [x] `bun run check:links` — 0 broken
- [x] Verified every internal Markdown link across `README.md`, `AGENTS.md`, `CONTRIBUTING.md`, and `docs/*.md` resolves to a real file